### PR TITLE
sorting arrows displayed next to the headers

### DIFF
--- a/app/controllers/user_box_scores_controller.rb
+++ b/app/controllers/user_box_scores_controller.rb
@@ -3,8 +3,12 @@ class UserBoxScoresController < ApplicationController
 
   def index
     # displays the league table, allows user to sort the table by headers clicks
+
     set_club_round
-    if params[:order]
+
+    # @order dictates the sorting order of the selected header
+    # it is passed from the partial _header_link.html.erb when a header is clicked
+    if params[:order] && (params[:exsort] == params[:sort])
       @order = params[:order].to_i
     else
       @order = -1
@@ -13,10 +17,12 @@ class UserBoxScoresController < ApplicationController
       @user_box_scores = rank_players(@round.user_box_scores)
       @user_box_scores.reverse! if @order == 1
     end
+    @sort = params[:sort]
+
     case params[:sort]
     when "Player"
       @user_box_scores = @round.user_box_scores.sort_by { |user_box_scores| user_box_scores.user.last_name }
-      @user_box_scores.reverse! if @order == -1
+      @user_box_scores.reverse! if @order == 1
     when "Points"
       @user_box_scores = @round.user_box_scores.sort_by { |user_box_scores| @order * user_box_scores.points }
     when "Box"
@@ -29,8 +35,6 @@ class UserBoxScoresController < ApplicationController
       @user_box_scores = @round.user_box_scores.sort_by { |user_box_scores| @order * user_box_scores.sets_played }
     when "Sets Won"
       @user_box_scores = @round.user_box_scores.sort_by { |user_box_scores| @order * user_box_scores.sets_won }
-    # else
-    #   @user_box_scores = rank_players(@round.user_box_scores) if @round
     end
     @rules = "A player's league position is determined by the total number of points won in a round.<br />
             In the event that two or more players have the same number of points the league position will be

--- a/app/views/user_box_scores/_header_link.html.erb
+++ b/app/views/user_box_scores/_header_link.html.erb
@@ -1,1 +1,3 @@
-<%=link_to header, user_box_scores_path(order: -@order, sort: header, round_start: @round.start_date, club_name: @round.club.name), class: "btn button-ghost"%>
+<% header_arrow = @order == 1 ? dir[0] : dir[1] %>
+<% header_arrow = header == @sort ? header_arrow : "" %>
+<%=link_to header+header_arrow, user_box_scores_path(exsort: @sort, order: -@order, sort: header, round_start: @round.start_date, club_name: @round.club.name), class: "btn button-ghost"%>

--- a/app/views/user_box_scores/_league_table.html.erb
+++ b/app/views/user_box_scores/_league_table.html.erb
@@ -10,8 +10,8 @@
         <div class="col-sm-1 text-padding"><%= "# #{user_box_score.rank}" %></div>
         <div class="col-sm-1 text-padding"><%= pluralize user_box_score.points, "pt" %></div>
         <div class="col-sm-1 text-padding"><%= "#{user_box_score.box.box_number}" %></div>
-        <div class="col-sm-2 text-padding"><%= pluralize user_box_score.games_played, "match" %></div>
-        <div class="col-sm-2 text-padding"><%= pluralize user_box_score.games_won, "match" %></div>
+        <div class="col-sm-1 text-padding"><%= pluralize user_box_score.games_played, "match" %></div>
+        <div class="col-sm-1 text-padding"><%= pluralize user_box_score.games_won, "match" %></div>
         <div class="col-sm-1 text-padding"><%= pluralize user_box_score.sets_played, "set" %></div>
         <div class="col-sm-1 text-padding"><%= pluralize user_box_score.sets_won, "set" %></div>
         <% if current_user.role == "admin" || current_user.role == "referee" %>

--- a/app/views/user_box_scores/index.html.erb
+++ b/app/views/user_box_scores/index.html.erb
@@ -14,16 +14,18 @@
     </div>
     <div class="frame-shape frame-padding">
       <p><%= sanitize @rules %></p>
+      <% up = ["↓", "↑"] %>
+      <% down = ["↑", "↓"]%>
       <ol type="1">
         <div class="row justify-content-center sticky-header font-bold">
-            <div class="col-sm-3"><%=render "header_link", header: "Player"%></div>
-            <div class="col-sm-1"><%=render "header_link", header: "Rank"%></div>
-            <div class="col-sm-1"><%=render "header_link", header: "Points"%></div>
-            <div class="col-sm-1"><%=render "header_link", header: "Box"%></div>
-            <div class="col-sm-2"><%=render "header_link", header: "Matches"%></div>
-            <div class="col-sm-2"><%=render "header_link", header: "Matches Won"%></div>
-            <div class="col-sm-1"><%=render "header_link", header: "Sets"%></div>
-            <div class="col-sm-1"><%=render "header_link", header: "Sets Won"%></div>
+            <div class="col-sm-3"><%=render "header_link", header: "Player", dir: up%></div>
+            <div class="col-sm-1"><%=render "header_link", header: "Rank", dir: up%></div>
+            <div class="col-sm-1"><%=render "header_link", header: "Points", dir: down%></div>
+            <div class="col-sm-1"><%=render "header_link", header: "Box", dir: up%></div>
+            <div class="col-sm-1"><%=render "header_link", header: "Matches", dir: down%></div>
+            <div class="col-sm-1"><%=render "header_link", header: "Matches Won", dir: down%></div>
+            <div class="col-sm-1"><%=render "header_link", header: "Sets", dir: down%></div>
+            <div class="col-sm-1"><%=render "header_link", header: "Sets Won", dir: down%></div>
         </div>
         <div>
           <%= render "league_table", user_box_scores: @user_box_scores %>


### PR DESCRIPTION
In the league table view, an up or down  arrow is displayed next to header when clicking on it to denote that players are displayed according to this header's order