### PR TITLE
added btn in Boxes index for referee to request new round

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
   def set_club_round
     # instantiate variables @club from params[:club_name], and @round from params[:round_start]
     # if they have been selected from the _select_club_round forms
-    # invoked by #index, #manage_my_box in Boxes and user_box_scores/index views forms
+    # invoked by #index, #my_box in Boxes and user_box_scores/index views forms
     clubs = Club.all.reject { |club| club == @sample_club }
     @club_names = clubs.map(&:name) # dropdown in the form
 
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
     Round.current.find_by(club_id: club_id) || Round.where(club_id: club_id).order(:start_date).last
   end
 
-  def my_box(round, player = current_user)
+  def my_own_box(round, player = current_user)
     # given a round, returns player's box for that round
     player.user_box_scores.map(&:box).select { |box| box.round == round }[0]
   end

--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -1,7 +1,7 @@
 class ChatroomsController < ApplicationController
   def show
     # display the chatroom
-    # method is accessed from either the navbar, or the show_referee or manage_my_box view pages
+    # method is accessed from either the navbar, or the show_referee or my_box view pages
     @current_box = current_user.user_box_scores.map(&:box).last
     if params[:chatroom]
       # coming from the form in show_referee view page
@@ -23,13 +23,13 @@ class ChatroomsController < ApplicationController
       # add the '#' in front of the chatroom names (for display in the form)
       @chatrooms = @chatrooms.map { |chatroom| "##{chatroom.name}" }
     else
-      # coming from the navbar or manage_my_box view page
+      # coming from the navbar or my_box view page
       @chatroom = Chatroom.find(params[:id])
       if @chatroom != @general_chatroom &&
          @chatroom.box.user_box_scores
                   .select { |user_box_score| user_box_score.user_id == current_user.id }.empty?
         flash[:notice] = t('.no_access_flash')
-        redirect_back(fallback_location: manage_my_box_path(0))
+        redirect_back(fallback_location: my_box_path(0))
       end
     end
     # instantiate @message for the new massage form

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,5 +1,6 @@
 class ContactsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:new, :create, :sent]
+  # skip_before_action :authenticate_user!, only: [:new, :create, :sent]
+  skip_before_action :authenticate_user!, only: %i[new create sent]
 
   def new
     @contact = Contact.new
@@ -9,7 +10,8 @@ class ContactsController < ApplicationController
     @contact = Contact.new(contact_params)
     @contact.request = request
     if @contact.deliver
-      redirect_to action: :sent
+      # redirect_to contacts_sent_path(request.parameters)
+      redirect_to contacts_sent_path(round_id: params[:contact][:round_id])
     else
       flash.now[:error] = t('.error_flash')
       render :new, status: :unprocessable_entity
@@ -17,11 +19,17 @@ class ContactsController < ApplicationController
   end
 
   def sent
+    # if processing a request new round (from Referee view page), then params[:round_id] is defined
+    if params[:round_id]
+      @round = Round.find(params[:round_id])
+      @club_name = @round.club.name
+    end
   end
 
   private
 
   def contact_params
-    params.require(:contact).permit(:subject, :name, :email, :phone, :message, :nickname, :files => [])
+    # params.require(:contact).permit(:subject, :name, :email, :phone, :message, :formcheck, :files => [])
+    params.require(:contact).permit(:subject, :name, :email, :phone, :message, :formcheck, :files, files: [])
   end
 end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -4,14 +4,14 @@ class MatchesController < ApplicationController
     @match = Match.find(params[:match_id])
     @current_user_match_score = match_score(@match, current_user)
     @opponent_match_score = match_score(@match, @opponent)
-    # @my_current_box = my_box(current_round(current_user.club_id))
+    # @my_current_box = my_own_box(current_round(current_user.club_id))
   end
 
   def new
     @page_from = params[:page_from]
     @round = Round.find(params[:round_id])
     @current_player = params[:player_id] ? User.find(params[:player_id]) : current_user
-    @box = my_box(@round, @current_player)
+    @box = my_own_box(@round, @current_player)
     if @round.start_date > Time.now
       flash[:notice] = t('.round_not_started_flash')
       redirect_back(fallback_location: box_referee_path(@box))
@@ -30,7 +30,7 @@ class MatchesController < ApplicationController
     # create new Match instance with the matches/new.html.erb form and 2 UserMatchScore instances
     @match = Match.new
     @current_player = User.find(params[:player_id])
-    @match.box = my_box(Round.find(params[:round_id]), @current_player)
+    @match.box = my_own_box(Round.find(params[:round_id]), @current_player)
     # get the court from the input court number (user inputs court number in lieu of court id)
     @match.court = Court.find_by name: params[:match][:court_id]
 
@@ -96,7 +96,7 @@ class MatchesController < ApplicationController
       rank_players(@match.box.round.user_box_scores)
 
       if current_user.role == "player"
-        redirect_to manage_my_box_path(@match.box, page_from: manage_my_box_path(@match.box))
+        redirect_to my_box_path(@match.box, page_from: my_box_path(@match.box))
       else
         redirect_to box_referee_path(@match.box, page_from: box_referee_path(@match.box))
       end
@@ -190,7 +190,7 @@ class MatchesController < ApplicationController
       # redirect_to user_box_scores_path(round_start: @round.start_date, club_name: @round.club.name)
 
       if current_user.role == "player"
-        redirect_to manage_my_box_path(match.box, page_from: manage_my_box_path(match.box))
+        redirect_to my_box_path(match.box, page_from: my_box_path(match.box))
       else
         redirect_to box_referee_path(match.box, page_from: box_referee_path(match.box))
       end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:home, :rules, :sitemap, :staff]
+  # skip_before_action :authenticate_user!, only: [:home, :rules, :sitemap, :staff]
+  skip_before_action :authenticate_user!, only: %i[home rules sitemap staff]
 
   def staff
     if current_user == @admin

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -1,6 +1,7 @@
 class RoundsController < ApplicationController
   def new
-    # admin or referee to generate next round from current: form
+    # invoked from button in Boxes index view
+    # admin to generate next round from current: form
     # if admin logged in, club given by params[:club_id]
     @current_round = current_round(params[:club_id] ? params[:club_id].to_i : current_user.club_id)
     @boxes = @current_round.boxes.sort

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -2,10 +2,12 @@ class Contact < MailForm::Base
   attribute :subject,   validate: true
   attribute :name,      validate: true
   attribute :email,     validate: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i
-  attribute :files,     attachment: true
+  # validate: { presence: true } works only when using the form without multiple: true
+  # otherwise the form yields "files"=>[""] in the params
+  attribute :files,     attachment: true, validate: { presence: true }
   attribute :phone,     validate: /\(?([0-9]{0,3})\)?([0-9]{0,10})/
   attribute :message,   validate: true
-  attribute :nickname,  captcha: true
+  attribute :formcheck, captcha: true
 
   def headers
     {

--- a/app/views/boxes/index.html.erb
+++ b/app/views/boxes/index.html.erb
@@ -35,9 +35,12 @@
 
     <% if current_user && current_user.role == "admin" %>
       <div class="buttons-wrap">
-        <!-- allow referee/admin to create next round up to 15 days before or 300 days after end of last round -->
+        <!-- allow referee/admin to create next round up to 15 days before or 300 days after end of last round
+        TO DO: add a time related condition here for the button to appear -->
         <%= link_to t(".create_round_btn"), new_round_path(club_id: @round.club_id), class: "btn buttons-shape btn-aqua" %>
       </div>
+    <% elsif current_user && current_user.role == "referee" %>
+        <%= link_to t(".request_round_btn"), contact_path(round_id: @round.id), class: "btn buttons-shape btn-aqua" %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/boxes/my_box.html.erb
+++ b/app/views/boxes/my_box.html.erb
@@ -5,7 +5,7 @@
     <% if @box %>
       <% @round = @box.round %>
     <% else %>
-      <%= render "shared/select_club_round", fallback_path: manage_my_box_path, intro_paragraph: t(".intro") %>
+      <%= render "shared/select_club_round", fallback_path: my_box_path, intro_paragraph: t(".intro") %>
     <% end %>
   </div>
   <% if @round %>

--- a/app/views/boxes/show.html.erb
+++ b/app/views/boxes/show.html.erb
@@ -5,7 +5,7 @@
     <div><%= render "shared/display_club_round", round: @box.round %></div>
     <div>
       <% if @this_is_my_box %>
-        <%= link_to t(".my_box_btn"), manage_my_box_path(@box), class: "btn buttons-shape btn-blue" %>
+        <%= link_to t(".my_box_btn"), my_box_path(@box), class: "btn buttons-shape btn-blue" %>
       <% end %>
       <!-- Link to view as list -->
       <%= link_to box_list_path, class: "btn buttons-shape btn-blue" do %>
@@ -101,7 +101,7 @@
     <%= link_to "Back", :back, class: "btn buttons-shape btn-blue" %>
 -->
     <% if @box == @my_current_box %>
-      <%= link_to "Enter new results", manage_my_box_path(@my_current_box), class: "btn buttons-shape btn-green" %>
+      <%= link_to "Enter new results", my_box_path(@my_current_box), class: "btn buttons-shape btn-green" %>
     <% else %>
       <%# link_to "My box results", box_path(@my_current_box), class: "btn buttons-shape btn-green" %>
     <% end %>

--- a/app/views/boxes/show_list.html.erb
+++ b/app/views/boxes/show_list.html.erb
@@ -5,7 +5,7 @@
     <div><%= render "shared/display_club_round", round: @box.round %></div>
     <div>
       <% if @this_is_my_box %>
-        <%= link_to t(".my_box_btn"), manage_my_box_path(@box), class: "btn buttons-shape btn-blue" %>
+        <%= link_to t(".my_box_btn"), my_box_path(@box), class: "btn buttons-shape btn-blue" %>
       <% end %>
       <!-- Link to view as table -->
       <%= link_to box_path, class: "btn buttons-shape btn-blue" do %>
@@ -34,7 +34,7 @@
           <span class=<%=user_box_matches[0].user == current_user ? "color-orange" : ""%>><%= render "shared/fullname", user: player %><%= "(# #{user_box_score.rank})" %> : <%= pluralize user_box_score.points, "point" %></span>
           <% player_matches = user_box_matches[1] %>
           <% if user_box_matches[0].user == current_user %>
-            <%# link_to "My box", manage_my_box_path(@box), class: "btn buttons-shape btn-blue" %>
+            <%# link_to "My box", my_box_path(@box), class: "btn buttons-shape btn-blue" %>
           <% end %>
           <ul>
             <% player_matches.each do |player_match| %>
@@ -76,7 +76,7 @@
     <%= link_to "Back", :back, class: "btn buttons-shape btn-blue" %>
   -->
     <% if @box == @my_current_box %>
-      <%= link_to t(".enter_results_btn"), manage_my_box_path(@my_current_box), class: "btn buttons-shape btn-green" %>
+      <%= link_to t(".enter_results_btn"), my_box_path(@my_current_box), class: "btn buttons-shape btn-green" %>
     <% else %>
       <%# link_to "My box", box_list_path(@my_current_box), class: "btn buttons-shape btn-green" %>
     <% end %>

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -1,8 +1,8 @@
 <!-- display or chose and display (admin/referee) a chatroom
-chatrooms for each box are created in Box controller #manage_my_box,
+chatrooms for each box are created in Box controller #my_box,
 if not already created in Round/new (TO DO), or in UserBoxScore/new (TO DO)-->
 <% if @chatroom %>
-<!-- coming from Box/manage_my_box -->
+<!-- coming from Box/my_box -->
   <div class="container"
     data-controller="chatroom-subscription"
     data-chatroom-subscription-chatroom-id-value="<%= @chatroom.id %>"

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,11 +1,24 @@
 <div class="container">
-  <br><h3><%= t '.contact_title' %></h3><hr>
-  <p><%= t '.p01' %></p>
+  <br>
+  <%# processing_round_request = params[:round_id] || (params[:contact] && params[:contact][:club_name]) %>
+  <% processing_new_round = params[:round_id] || (params[:contact] && params[:contact][:round_id]) %>
+  <% if processing_new_round %>
+    <!--- coming from the Boxes show_referee view (request a new round creation) -->
+    <h3><%= t '.new_round_title' %></h3>
+  <% else %>
+    <!--- coming from the footer partial (contact us) -->
+    <h3><%= t '.contact_title' %></h3><hr>
+    <p><%= t '.p01' %></p>
+  <% end %>
   <div class="frame-shape contact-wrap">
     <%= simple_form_for @contact do |f| %>
       <% if @contact.errors.any? %>
+          <%# t('.error_invite') %>
           <div id="error_explanation" class="bg-rose-200 pt-3 pb-1 mb-4 px-4 rounded-md">
-              <div class="font-bold text-rose-700 text-sm pb-4"><%= pluralize(@contact.errors.count, "error") %> prohibited this page from being saved:</div>
+              <div class="font-bold text-rose-700 text-sm pb-4">
+                <!---<%= pluralize(@contact.errors.count, "error") %> prohibited this page from being saved: --->
+                <%= "#{t('.error', count: @contact.errors.count)} #{t('.error_message')}" %><br>
+              </div>
 
               <ul class="pb-0 mb-0">
                   <% @contact.errors.each do |error| %>
@@ -15,49 +28,117 @@
           </div>
       <% end %>
       <div class="contact-align contact-space-between">
-        <div><%= f.input :subject,
-          label: false,
-          # collection: ['Provide feedback', 'Join one of our clubs', 'Any other topic'],
-          collection: t('.topics').map { |item| item.values }.flatten,
-          prompt: t('.prompt'),
-          input_html: {class: "contact-field", style: "width: 350px"},
-          required: true
-        %></div>
-        <% default = current_user ? "#{current_user.first_name} #{current_user.last_name}" : "" %>
+        <div>
+          <!--- FORM FIELD: subject -->
+          <% if processing_new_round %>
+            <!--- coming from the Boxes show_referee view (request a new round creation) -->
+            <% round = Round.find(processing_new_round) %>
+            <% default_subject =  t('.new_round_subject', club: round.club.name)%>
+            <%= f.input :subject,
+              label: false,
+              prompt: t('.prompt'),
+              input_html: {class: "contact-field", style: "width: 350px", value: default_subject},
+              required: true
+            %>
+          <% else %>
+            <!--- coming from the footer partial (contact us) -->
+            <%= f.input :subject,
+              label: false,
+              # collection: ['Provide feedback', 'Join one of our clubs', 'Any other topic'],
+              collection: t('.topics').map { |item| item.values }.flatten,
+              prompt: t('.prompt'),
+              input_html: {class: "contact-field", style: "width: 350px"},
+              required: true
+            %>
+          <% end %>
+        </div>
+
+        <!--- FORM FIELD: name -->
+        <% default_name = current_user ? "#{current_user.first_name} #{current_user.last_name}" : "" %>
         <div><%= f.input :name,
-          input_html: {class: "contact-field", style: "width: 350px", value: default},
           label: false,
           placeholder: t('.name_placeholder'),
+          input_html: {class: "contact-field", style: "width: 350px", value: default_name},
           required: true
         %></div>
       </div>
       <div class="contact-align contact-space-between">
-        <% default = current_user ? current_user.email : "" %>
+
+        <!--- FORM FIELD: email address -->
+        <% default_email = current_user ? current_user.email : "" %>
         <div><%= f.input :email,
-          input_html: {class: "contact-field", style: "width: 350px", value: default},
           label: false,
           placeholder: t('.email_placeholder'),
+          input_html: {class: "contact-field", style: "width: 350px", value: default_email},
           required: true
         %></div>
+
+        <!--- FORM FIELD: phone number -->
+        <% default_phone = current_user ? current_user.phone_number : "" %>
         <div><%= f.input :phone,
-          input_html: {class: "contact-field", style: "width: 350px"},
           label: false,
           placeholder: t('.phone_placeholder'),
+          input_html: {class: "contact-field", style: "width: 350px", value: default_phone},
           required: false
         %></div>
       </div>
+
+      <!--- FORM FIELD: message body -->
+      <% if processing_new_round %>
+        <!--- coming from the Boxes show_referee view (request a new round creation) -->
+        <% round = Round.find(processing_new_round) %>
+        <% duration = ((round.end_date + 1 - round.start_date).to_f / 365 * 12).round %>
+        <% start_date = l(round.end_date + 1, format: :default) %>
+        <% end_date = l(round.end_date >> duration, format: :default) %>
+        <% default_message = t('.new_round_message',
+                                  start_date: start_date, end_date: end_date,
+                                  club: round.club.name,
+                                  sender: default_name) %>
+      <% else %>
+        <!--- coming from the footer partial (contact us) -->
+        <% default_message = "" %>
+      <% end %>
       <%= f.input :message,
         as: "text",
         label: false,
-        input_html: {class: "contact-field contact-content"},
+        input_html: {class: "contact-field contact-content", value: default_message},
         required: true
       %>
-      <%= f.text_field :nickname,
+
+      <!--- FORM FIELD: security check (hidden) -->
+      <%= f.text_field :formcheck,
         type:"hidden"
       %>
-      <div>
-      <%= f.file_field :files, multiple: true, class: 'btn buttons-shape btn-beige mb-3', accept: 'image/png,image/gif,image/jpeg,application/pdf' %>
-      </div>
+      <% if processing_new_round %>
+        <!--- coming from the Boxes show_referee view (request a new Round creation) -->
+
+        <!--- FORM FIELD: round id = passing parameters to the Sent view (hidden) -->
+        <%= f.text_field :round_id,
+          type:"hidden",
+          value: round.id
+        %>
+        <div>
+
+          <!--- FORM FIELD: files attachment (one file for new Round request) -->
+          <!--- NB: "required: true" with "validate: { presence: true }" in the Contact model
+          would not work with "multiple : true" since no attachment yields "files"=>[""] in the params -->
+          <%= f.file_field :files,
+            class: 'btn buttons-shape btn-beige mb-3',
+            accept: 'text/csv,application/msword,application/vnd.ms-excel,application/pdf',
+            required: true
+          %>
+        </div>
+      <% else %>
+
+        <!--- FORM FIELD: files attachment (multi file for Contact us) -->
+        <div>
+          <%= f.file_field :files,
+            multiple: true,
+            class: 'btn buttons-shape btn-beige mb-3',
+            accept: 'image/png,image/gif,image/jpeg,application/pdf'
+          %>
+        </div>
+      <% end %>
       <%= f.submit t('.send_btn'),
         class: "btn buttons-shape btn-beige mb-3"
       %>

--- a/app/views/contacts/sent.html.erb
+++ b/app/views/contacts/sent.html.erb
@@ -4,15 +4,24 @@
   <div class="frame-shape frame-padding text-size">
     <h3><%= t '.sent_title' %></h3>
     <br>
-    <p><%= t '.p01_html' %></p>
-    <% if current_user %>
-      <p><%= t '.p02' %></p>
+    <% if params[:round_id] %>
+      <p><%= t('.p04_html', club_name: @round.club.name) %></p>
     <% else %>
-      <p><%= t '.p03' %></p>
+      <p><%= t '.p01_html' %></p>
+      <% if current_user %>
+        <p><%= t '.p02' %></p>
+      <% else %>
+        <p><%= t '.p03' %></p>
+      <% end %>
     <% end %>
   </div>
   <br>
   <div class = "buttons-wrap">
-    <%= link_to t(".back_btn"), root_path, class: "btn buttons-shape btn-green" %>
+    <% if params[:round_id] %>
+      <%# link_to t(".back_btn"), boxes_path(request.params.except(:action, :controller)), class: "btn buttons-shape btn-green" %>
+      <%= link_to t(".back_btn"), boxes_path(round_start: @round.start_date, club_name: @round.club.name), class: "btn buttons-shape btn-green" %>
+    <% else %>
+      <%= link_to t(".home_btn"), root_path, class: "btn buttons-shape btn-green" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/matches/edit.html.erb
+++ b/app/views/matches/edit.html.erb
@@ -66,7 +66,7 @@
       data: {turbo_method: :delete, turbo_confirm: t(".sure")} %>
       &nbsp;&nbsp;&nbsp;&nbsp;
       <% if current_user.role == "player" %>
-        <%= link_to t(".back_btn"), manage_my_box_path(@match.box, page_from: manage_my_box_path(@match.box)), class: "btn buttons-shape btn-blue" %>
+        <%= link_to t(".back_btn"), my_box_path(@match.box, page_from: my_box_path(@match.box)), class: "btn buttons-shape btn-blue" %>
       <% else %>
         <%= link_to t(".back_btn"), box_referee_path(@match.box, page_from: box_referee_path(@match.box)), class: "btn buttons-shape btn-blue" %>
       <% end %>

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -59,7 +59,7 @@
       <%= f.submit t(".save_score_btn"), class: "btn buttons-shape btn-green" %>
       &nbsp;&nbsp;&nbsp;&nbsp;
       <% if current_user.role == "player" %>
-        <%= link_to t(".back_btn"), manage_my_box_path(@box, page_from: manage_my_box_path(@box)), class: "btn buttons-shape btn-blue" %>
+        <%= link_to t(".back_btn"), my_box_path(@box, page_from: my_box_path(@box)), class: "btn buttons-shape btn-blue" %>
       <% else %>
         <%= link_to t(".back_btn"), box_referee_path(@box, page_from: box_referee_path(@box)), class: "btn buttons-shape btn-blue" %>
       <% end %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,4 +1,4 @@
-<!-- player: show match/user_match_scores details (called from boxes/manage_my_box.html.erb) -->
+<!-- player: show match/user_match_scores details (called from boxes/my_box.html.erb) -->
 <div class="container">
   <% player_ubs = UserBoxScore.find_by(box_id: @match.box.id, user_id:current_user.id) %>
   <% opponent_ubs = UserBoxScore.find_by(box_id: @match.box.id, user_id:@opponent.id) %>
@@ -35,7 +35,7 @@
   </div>
   <br>
   <div class="buttons-wrap">
-    <%# link_to "Back to my box", manage_my_box_path(@my_current_box), class: "btn buttons-shape btn-blue" %>
-    <%= link_to t(".back_btn"), manage_my_box_path(@match.box), class: "btn buttons-shape btn-blue" %>
+    <%# link_to "Back to my box", my_box_path(@my_current_box), class: "btn buttons-shape btn-blue" %>
+    <%= link_to t(".back_btn"), my_box_path(@match.box), class: "btn buttons-shape btn-blue" %>
   </div>
 </div>

--- a/app/views/pages/sitemap.html.erb
+++ b/app/views/pages/sitemap.html.erb
@@ -38,7 +38,6 @@
     <% if current_user && current_user.role != "player" %>
       <br><h5><%= t '.referee_view' %></h5>
       <p><%= t '.p14_html' %></p>
-      <p><%= t '.p15' %></p>
 
     <% else %>
       <br><h5><%= t '.table_view' %></h5>
@@ -49,7 +48,7 @@
       <p><%= t '.p19_html' %></p>
       <p><%= t '.p20_html' %></p>
 
-      <br><h5><%= t '.manage_my_box' %></h5>
+      <br><h5><%= t '.my_box' %></h5>
       <p><%= t '.p22_html' %></p>
       <p><%= t '.p23' %></p>
     <% end %>
@@ -69,6 +68,21 @@
       <br><h5><%= t '.match_edit_score' %></h5>
       <p><%= t '.p26' %></p>
     <% end %>
+
+    <br><h5><%= t '.chatrooms' %></h5>
+    <% if current_user && current_user.role != "player" %>
+      <p><%= t '.p28_html' %></p>
+    <% else %>
+      <p><%= t '.p27_html' %></p>
+    <% end %>
+    <ul>
+      <li><%= t '.li08_html' %></li>
+      <li><%= t '.li09_html' %></li>
+      <li><%= t '.li10_html' %></li>
+      <li><%= t '.li11_html' %></li>
+      <li><%= t '.li12_html' %></li>
+    </ul></p>
+    <p><%= t '.p29' %></p>
 
     <button  data-action="click->toggle#scrollToTop" data-toggle-target="topButton"
       class="btn buttons-shape btn-blue button-top d-none"><i class="fa-solid fa-up-long"></i>

--- a/app/views/pages/staff.html.erb
+++ b/app/views/pages/staff.html.erb
@@ -51,8 +51,8 @@
     <%= link_to "Tournament rules", rules_path, class: "btn buttons-shape btn-green" %>
     <%= link_to "Website map", sitemap_path, class: "btn buttons-shape btn-green" %>
     <% if current_user && current_user.role == "player" %>
-      <%# passing 0 to manage_my_box_path, forces user to chose a round %%>
-      <%= link_to "My box", manage_my_box_path(0), class: "btn buttons-shape btn-green" %>
+      <%# passing 0 to my_box_path, forces user to chose a round %%>
+      <%= link_to "My box", my_box_path(0), class: "btn buttons-shape btn-green" %>
     <% end %>
   </div>
   -->

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -29,8 +29,8 @@
               <%= link_to t('.all_boxes_link'), boxes_path, class: "dropdown-item" %>
               <%= link_to t('.league_table_link'), user_box_scores_path, class: "dropdown-item" %>
               <% if current_user && current_user.role == "player" %>
-                <!-- passing 0 to manage_my_box_path forces the _select_club_round form -->
-                <%= link_to t('.my_box_link'), manage_my_box_path(0), class: "dropdown-item color-tennis-blue" %>
+                <!-- passing 0 to my_box_path forces the _select_club_round form -->
+                <%= link_to t('.my_box_link'), my_box_path(0), class: "dropdown-item color-tennis-blue" %>
               <% end %>
               <% if current_user.role == "player" %>
                 <%= link_to t('.general_chat_link'), chatroom_path(@general_chatroom), class: "dropdown-item" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,7 +46,7 @@ en:
       ddmmm_date: "%d %b"
       wwwddmmmyy_time: "%a %-d %b %y"   # Tue 9 May 23 wwwddmmmyy_time
       wwwddmmm_at_hhmm: "%a %-d %b at %H:%M"
-      wwwddmmmyy_at_hhmm: "%a %-d %b %y at %H:%M"
+      wwwddmmmyy_at_hhmm: "%A %-d %b %Y at %H:%M"
 fr:
   date:
     formats:
@@ -74,7 +74,7 @@ fr:
       wwwddmmmyy_date: "%a %-d %b %y"  # ven 14 avr. 23   # wwwddmmmyy_at_hhmm
       ddmmm_date: "%d %b"              # 2 mai
       wwwddmmm_at_hhmm: "%a %-d %b à %H:%M"
-      wwwddmmmyy_at_hhmm: "%a %-d %b %y à %H:%M"
+      wwwddmmmyy_at_hhmm: "%A %-d %b %Y à %H:%M" # vendredi 14 avr. 2023
     am: 'am'
     pm: 'pm'
 nl:
@@ -109,6 +109,6 @@ nl:
       ddmmm_date: "%d %b"
       wwwddmmmyy_time: "%a %-d %b %y"   # Tue 9 May 23 wwwddmmmyy_time
       wwwddmmm_at_hhmm: "%a %-d %b at %H:%M"
-      wwwddmmmyy_at_hhmm: "%a %-d %b %y at %H:%M"
+      wwwddmmmyy_at_hhmm: "%A %-d %b %Y at %H:%M"
   am: "'s ochtends"
   pm: "'s middags"

--- a/config/locales/views/boxes/en.yml
+++ b/config/locales/views/boxes/en.yml
@@ -9,7 +9,8 @@ en:
       click_box_pop: Click on a box to view match details
       message_box_pop: <b>Box columns:</b><br />player name, rank,<br />games played, box points
       create_round_btn: Create the next round
-    manage_my_box:
+      request_round_btn: Request the admin the next round
+    my_box:
       my_box_results: My box results
       intro: For a given round, view <b>your box</b><br />and view your match details or enter your new scores in your club
       not_in_round: " you are not in this round!"
@@ -18,17 +19,17 @@ en:
       total_points_header: Total points
       played_on_header: Match played on
       action_header: Action
-      view_box_results_btn: View box results
-      see_match_result_btn: See match result
+      view_box_results_btn: Display my box
+      see_match_result_btn: See match score
       enter_score_btn: Enter new score
       chat_in_my_box: Chat with other players in my box
-      access_chatroom_btn: Access the chatroom
+      access_chatroom_btn: Access the box chatroom
     show_list:
       list_view: list view
       my_box_btn: My box
-      match_score_header: Match score
-      player_points_header: Player's points
       match_earnings: Match earnings
+      match_score_header: Match scores
+      player_points_header: Player's points
       opponent_points_header: Opponent's points
       opponent_total_points_header: Opponent's total points
       points_pop: >
@@ -45,7 +46,7 @@ en:
       not_authorised: As a player, this page is not authorised
       pop01_a: select a match to edit or delete the score
       pop01_b: ", or input a new score"
-      match_score_header: Match score
+      match_score_header: Match scores
       player_points_header: Player's points
       opponent_points_header: Opponent's points
       opponent_total_points_header: Opponent's total points

--- a/config/locales/views/boxes/fr.yml
+++ b/config/locales/views/boxes/fr.yml
@@ -9,7 +9,8 @@ fr:
       click_box_pop: Cliquez une box pour les détails des matchs
       message_box_pop: <b>Colonnes</b><br />joueur, classement,<br />matchs joués, points cumulés
       create_round_btn: Créer le prochain round
-    manage_my_box:
+      request_round_btn: Demander la création du prochain round
+    my_box:
       my_box_results: Ma box
       intro: Pour le round choisi, accédez à <b>votre box</b><br />pour voir les détails de vos match, et saisir de nouveaux scores
       not_in_round: " vous n'êtes pas dans ce round!"
@@ -18,17 +19,17 @@ fr:
       total_points_header: Cumul points
       played_on_header: Match joué le
       action_header: Action
-      view_box_results_btn: Résultats box
-      see_match_result_btn: Résultats match
-      enter_score_btn: Saisissez un score
+      view_box_results_btn: Résultats de ma box
+      see_match_result_btn: Score du match
+      enter_score_btn: Saisir un score
       chat_in_my_box: Discutez avec les joueurs de votre box
-      access_chatroom_btn: Accédez à la chatroom
+      access_chatroom_btn: Chatroom de votre box
     show_list:
       list_view: liste de résultats
       my_box_btn: Ma box
-      match_score_header: Score match
-      player_points_header: Points joueur
       match_earnings: Points du match
+      match_score_header: Scores match
+      player_points_header: Points joueur
       opponent_points_header: Points adversaire
       opponent_total_points_header: Cumul adversaire
       points_pop: >
@@ -45,7 +46,7 @@ fr:
       not_authorised: Page non authorisée
       pop01_a: choisissez un match à éditer ou supprimez le score
       pop01_b: ", ou saisissez un nouveau score"
-      match_score_header: Score match
+      match_score_header: Scores match
       player_points_header: Points joueur
       opponent_points_header: Points adversaire
       opponent_total_points_header: Cumul adversaire

--- a/config/locales/views/boxes/nl.yml
+++ b/config/locales/views/boxes/nl.yml
@@ -9,7 +9,8 @@ nl:
       click_box_pop: Klik op een vakje voor wedstrijddetails
       message_box_pop: <b>Kopteksten</b><br />speler, ranking,<br />gespeelde wedstrijden, verzamelde punten
       create_round_btn: Maak de volgende ronde
-    manage_my_box:
+      request_round_btn: Vraag de admin de volgende ronde aan
+    my_box:
       my_box_results: Mijn box
       intro: Ga voor de gekozen ronde naar <b>uw box</b><br /> om de details van uw wedstrijden te bekijken en nieuwe scores in te voeren
       not_in_round: " jij zit niet in deze ronde!"
@@ -18,17 +19,17 @@ nl:
       total_points_header: Accumulatiepunten
       played_on_header: Wedstrijd gespeeld
       action_header: Actie
-      view_box_results_btn: Boxresultaten
-      see_match_result_btn: Wedstrijdresultaten
+      view_box_results_btn: Mijn boxresultaten
+      see_match_result_btn: Wedstrijdscore
       enter_score_btn: Voer een score in
       chat_in_my_box: Chat met de spelers in uw box
-      access_chatroom_btn: Toegang tot de chatroom
+      access_chatroom_btn: Chatroom van uw box
     show_list:
       list_view: resultaten lijst
       my_box_btn: Mijn box
-      match_score_header: Wedstrijdscore
-      player_points_header: Spelerpunten
       match_earnings: Matchpunten
+      match_score_header: Wedstrijdscores
+      player_points_header: Spelerpunten
       opponent_points_header: Tegenstander punten
       opponent_total_points_header: Tegenstander accumulatiepunten
       points_pop: >
@@ -45,7 +46,7 @@ nl:
       not_authorised: Ongeautoriseerde pagina
       pop01_a: kies een wedstrijd om de score te bewerken of te verwijderen
       pop01_b: ", of voer een nieuwe score in"
-      match_score_header: Wedstrijdscore
+      match_score_header: Wedstrijdscores
       player_points_header: Spelerpunten
       opponent_points_header: Tegenstander punten
       opponent_total_points_header: Tegenstander accumulatiepunten

--- a/config/locales/views/contacts/en.yml
+++ b/config/locales/views/contacts/en.yml
@@ -2,21 +2,44 @@ en:
   contacts:
     new:
       contact_title: Contact us
+      new_round_title: Request a new round creation
+      error_invite: Please review the following error message
+      error:
+        zero: 0 errors
+        one: 1 error
+        other: "%{count} errors"
+      error_message: "prohibited this form from being sent:"
       p01: Score disputes should be dealt in your box chatroom
       prompt: Select a topic →
       topics:
       - feedback: Provide feedback
       - join_club: Join one of our clubs
       - other_topic: Any other topic
+      new_round_subject: "New round request for the %{club}"
+      new_round_message: >
+        From %{start_date} until %{end_date} (dd/mm/yy). A players list is attached.
+        Regards %{sender}
       name_placeholder: Full name
       email_placeholder: e-mail address user@domain.com
       phone_placeholder: Phone number
+      file_attached: No file is attached. Send anyway?
       send_btn: Send
     sent:
       sent_title: Message sent!
       p01_html: Thank you for your message. Your <b>admin</b> will get back to you soon.
       p02: In the meantime, 🎾 keep playing your league box matches! 🎾
       p03: In the meantime, 🎾 visit our Tournament rules pages! 🎾
-      back_btn: Back to home
+      p04_html: >
+        Thank you for requesting a new round creation for %{club_name}.<br>
+        Your <b>admin</b> will get back to you soon.
+      back_btn: Back
+      home_btn: Home page
     create:
       error_flash: Could not send message
+  mail_form:
+    errors:
+      models:
+        contact:
+          attributes:
+            files:
+              blank: ": an attached list of players is required (accepted formats: csv, msword, ms-excel, pdf)"

--- a/config/locales/views/contacts/fr.yml
+++ b/config/locales/views/contacts/fr.yml
@@ -2,21 +2,54 @@ fr:
   contacts:
     new:
       contact_title: Contact
-      p01: Réglez les différends sur les scores à partir de votre chatroom
+      new_round_title: Demande de création d'un nouveau round
+      error_invite: Veuillez consulter le message d'erreur suivant
+      error:
+        zero: 0 erreur empêche
+        one: 1 erreur empêche
+        other: "%{count} erreurs empêchent"
+      error_message: "l'envoi de ce formulaire:"
+      p01: Les différends sur les scores devront être traités depuis votre chatroom de box
       prompt: Choisir un sujet →
       topics:
       - feedback: Donnez un feedback
       - join_club: Rejoignez un de nos clubs
       - other_topic: Autre sujet
+      new_round_subject: "Demande: nouveau round pour le %{club} - New round request"
+      new_round_message: >
+        Du %{start_date} au %{end_date} (dd/mm/yy). La liste des joueurs est en attachement (a players list is attached)
+        Cordialement %{sender}
       name_placeholder: Nom complet
       email_placeholder: adresse e-mail user@domain.com
       phone_placeholder: Téléphone
+      file_attached: Il n'y a pas de fichier attaché. Envoyer tout de même?
       send_btn: Envoi
     sent:
       sent_title: Message envoyé!
       p01_html: Merci de votre message. Votre <b>admin</b> vous contactera bientôt.
-      p02: En attendant, 🎾 continuez à jouer vos matchs de box league! 🎾
-      p03: En attendant, 🎾 visitez notre page Règles tournoi! 🎾
-      back_btn: Page d'accueil
+      p02: 🎾 En attendant, continuez à jouer vos matchs de box league! 🎾
+      p03: 🎾 En attendant, visitez notre page Règles tournoi! 🎾
+      p04_html: >
+        Merci de votre demande de création d'un nouveau round pour le %{club_name}.<br>
+        Votre <b>admin</b> vous contactera bientôt.
+      back_btn: Retour
+      home_btn: Page d'accueil
     create:
       error_flash: Erreur d'envoi du message
+  mail_form:
+    errors:
+      models:
+        contact:
+          attributes:
+            subject:
+              blank: ne peut pas être vide
+            name:
+              blank: ne peut pas être vide
+            phone:
+              blank: ne peut pas être vide
+            email:
+              blank: ne peut pas être vide
+            message:
+              blank: ne peut pas être vide
+            files:
+              blank: ": un fichier attaché avec la liste de joueurs est requis (formats acceptés: csv, msword, ms-excel, pdf)"

--- a/config/locales/views/contacts/nl.yml
+++ b/config/locales/views/contacts/nl.yml
@@ -2,21 +2,54 @@ nl:
   contacts:
     new:
       contact_title: Contact
-      p01: Los scoregeschillen op vanuit uw chatroom
+      new_round_title: Request a new round creation
+      error_invite: Bekijk het volgende foutbericht
+      error:
+        zero: 0 fout zorgd
+        one: 1 fout zorgd
+        other: "%{count} fouten zorgden"
+      error_message: "heeft de verzending van dit formulier verboden:"
+      p01: Los scoregeschillen op vanuit uw box-chatroom
       prompt: Kies een onderwerp →
       topics:
       - feedback: Geef feedback
       - join_club: Sluit je aan bij een van onze clubs
       - other_topic: Ander onderwerp
+      new_round_subject: "Nieuw rondeverzoek voor de %{club} - New round request"
+      new_round_message: >
+        Van %{start_date} tot %{end_date} (dd/mm/yy). Een spelerslijst is bijgevoegd (a players list is attached)
+        Groetjes %{sender}
       name_placeholder: Voor-en achternaam
       email_placeholder: e-mailadres user@domain.com
       phone_placeholder: Telefoon
+      file_attached: Er is geen bestand bijgevoegd. Toch versturen?
       send_btn: Verzenden
     sent:
       sent_title: Bericht verzonden!
       p01_html: Bedankt voor je bericht. Uw <b>admin</b> neemt binnenkort contact met u op.
       p02: 🎾 Blijf ondertussen je boxcompetitiewedstrijden spelen! 🎾
       p03: 🎾 Bezoek in de tussentijd onze pagina Toernooiregels! 🎾
-      back_btn: Home
+      p04_html: >
+        Bedankt voor het aanvragen van een nieuwe rondecreatie voor %{club_name}.<br>
+        Uw <b>admin</b> neemt binnenkort contact met u op.
+      back_btn: Rug
+      home_btn: Home-pagina
     create:
       error_flash: Fout bij verzenden van bericht
+  mail_form:
+    errors:
+      models:
+        contact:
+          attributes:
+            subject:
+              blank: kan niet leeg zijn
+            name:
+              blank: kan niet leeg zijn
+            phone:
+              blank: kan niet leeg zijn
+            email:
+              blank: kan niet leeg zijn
+            message:
+              blank: kan niet leeg zijn
+            files:
+              blank: ": een bijgevoegde lijst met spelers is vereist (geaccepteerde formaten: csv, msword, ms-excel, pdf)"

--- a/config/locales/views/matches/en.yml
+++ b/config/locales/views/matches/en.yml
@@ -33,4 +33,4 @@ en:
       submitted: "submitted on %{date} by %{user}."
       points_earned: "Points earned : "
       challenge: "To challenge or edit this match score, please contact your club referee %{referee}."
-      back_btn: Back to my box
+      back_btn: Back to My box

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -160,8 +160,8 @@ en:
       sitemap_title: LeagueBox sitemap
       home: Home
       p01: General presentation of the Box League Tournament
-      overview_rules: Tournament overview and rules
-      p03: Explanation of the Box League rules
+      overview_rules: Tournament rules
+      p03: Tournament overview and explanation of the Box League rules
       club_staff: Club staff
       p05: Details of the admin and the club referee
       all_boxes: All Boxes
@@ -170,7 +170,7 @@ en:
       li02: ranking in the league
       li03: number of matches played
       li04: number of total points
-      p08_html: "<span class= 'color-orange'>Current player</span> appears in orange."
+      p08_html: "Current player appears in <span class='color-orange'>orange</span>."
       p09a: Clicking on a box leads to the Box Referee view.
       p09b: Clicking on a box leads to the Box Table view.
       p10a_html: When reaching the end of the round, a footpage button <span class='color-tennis-aqua'>Create the next round</span> appears.
@@ -178,27 +178,47 @@ en:
       p11_html: Each player appears in descending rank order under the headers <b>Player, Rank, Points, Box, Matches </b>(matches played)<b>, Won </b>(matches won)<b>, Sets </b>(sets played)<b>, Won </b>(sets won).
       p12: Clicking on a header sorts the player according to this header.
       referee_view: Box referee view
-      p14_html: Each player's matches which have been played are shown as list items. Headers are <b>Match scores, Player match points, Opponent match points, Opponent's total points</b>. Unplayed matchs are listed too.
-      p15: Clicking on a match line lands on the Match Edit/Delete page, clicking on an unplayed match (admin only) lands on the New match score page.
+      p14_html: >
+        Each player's matches which have been played are shown as list items.
+        Headers are <b>Match scores</b>, <b>Player's points</b>, <b>Opponent's points</b>, <b>Opponent's total points</b>.<br>
+        Unplayed matchs are listed too.<br><br>
+        Clicking on a match line lands on the <b>Match Edit/Delete</b> page, clicking on an unplayed match (admin only) lands on the <b>New match score</b> page.
       table_view: Box Table view
       p16: Each player's matches are shown under their corresponding opponent.
       p17_html: >
-        If on <span class= 'color-orange'>Current player</span>'s box, the name appears in orange, and <span class='color-tennis-blue'>My box</span> button appears
+        If on Current player's box, the name appears in <span class='color-orange'>orange</span>, and a <span class='color-tennis-blue'>My box</span> button appears
         next to the toggle link to <span class='color-tennis-blue'>List view</span> ( <i class='fa-solid fa-list color-tennis-blue'></i> ).
       list_view: Box List view
-      p19_html: Each player's matches which have been played are shown as list items. Headers are <b>Match scores, Player match points, Opponent match points, Opponent's total points</b>.
+      p19_html: Each player's matches which have been played are shown as list items. Headers are <b>Match scores, Player's points, Opponent's points, Opponent's total points</b>.
       p20_html: >
-        If on <span class= 'color-orange'>Current player</span>'s box, the name appears in orange, and <span class='color-tennis-blue'>My box</span> button appears
+        If on Current player's box, the name appears in <span class='color-orange'>orange</span>, and a <span class='color-tennis-blue'>My box</span> button appears
         next to the toggle link to <span class='color-tennis-blue'>Table view</span> ( <i class='fa-regular fa-table-list color-tennis-blue'></i> ).
-      manage_my_box: My box
-      p22_html: Each of my box matches dates and players points with links such as <span class='color-tennis-blue'>Display my box</span>, <span class='color-tennis-blue'>See match results</span>, and <span class='color-tennis-blue'>Enter new score</span>.
+      my_box: My box
+      p22_html: Each of my box matches dates and players points with links such as <span class='color-tennis-blue'>Display my box</span>, <span class='color-tennis-blue'>See match score</span>, and <span class='color-tennis-blue'>Enter new score</span>.
       p23: Link to the box chatroom.
       match_results: Match results view
       p24: "Details of a match played:"
-      li05: game date and time, court number,
-      li06: score, with date and time of submission,
+      li05: game date and time, court number
+      li06: score, with date and time of submission
       li07: match earnings and total points.
       new_match_score: New match score
       p25: Form to enter new match details.
       match_edit_score: Match edit score
       p26: Form to modify match details, or delete score.
+      chatrooms: Chatrooms
+      p27_html: >
+        The <b>#general chatroom</b>, accessible from the main menu, is open to all players, regardless of their club.<br>
+        Users must use it for their general communication, and must exercise moderation.<br>
+        A <b>box chatroom</b> also exists for each tournament box, accessible from the <b>My Box</b> page.<br><br>
+        A color is assigned to messages, according to their author:<br>
+      p28_html: >
+        The <b>#general chatroom</b> and the <b>box chatrooms</b> are accessible from the main menu. The #general chatroom is open to all players, whatever their club.<br>
+        Users must use it for their general communication, and must exercise moderation.<br>
+        Each <b>box chatroom</b> dedicated to a box in the tournament is accessible from the <b>My Box</b> page available to players.<br><br>
+        A color is assigned to messages, according to their author:<br>
+      li08_html: <span class='color-tennis-blue'>Those of players from the same club appear in blue</span>
+      li09_html: <span class='color-tennis-aqua'>Those of Referee of the same club appear in aqua</span>
+      li10_html: <span class= 'color-grey'>Those of players from other clubs appear in light gray</span>
+      li11_html: <span class= 'color-black'>Those of the Referee from another club appear in dark gray</span>
+      li12_html: <span class= 'color-tennis-red'>Those of the admin appear in red</span>
+      p29: Received messages appear on the left of the screen, and sent messages on the right.

--- a/config/locales/views/pages/fr.yml
+++ b/config/locales/views/pages/fr.yml
@@ -161,8 +161,8 @@ fr:
       sitemap_title: Plan du site LeagueBox
       home: Page d'accueil
       p01: Présentation générale du Tournoi de la Box League
-      overview_rules: Description du Tournoi et règles
-      p03: Explication des règles de la Box League
+      overview_rules: Le Tournoi
+      p03: Description du Tournoi et explication des règles de la Box League
       club_staff: Personnel du club
       p05: Coordonnées de l'admin et du Referee du club
       all_boxes: Les Box
@@ -171,7 +171,7 @@ fr:
       li02: son classement dans le tournoi
       li03: le nombre de matchs joués
       li04: le cumul de ses points
-      p08_html: "Le <span class= 'color-orange'>joueur connecté</span> apparaît en orange."
+      p08_html: "Le joueur connecté apparaît en <span class='color-orange'>orange</span>."
       p09a: Un clic sur une box conduit à la vue Box Referee.
       p09b: Un clic sur une box conduit à la vue en Grille.
       p10a_html: À l'approche de la fin du round, un bouton de pied de page pour <span class='color-tennis-aqua'>Créer le prochain round</span> apparaît.
@@ -179,27 +179,46 @@ fr:
       p11_html: Chaque joueur apparaît du mieux au moins bien classé sous les entêtes <b>Joueur, Classement, Points, Box, Matchs </b>(matchs joués)<b>, Gagnés </b>(matchs gagnés)<b>, Sets </b>(sets joués)<b>, Gagnés </b>(sets gagnés).
       p12: En cliquant sur un entête, les joueurs se classent selon cet entête.
       referee_view: Vue referee
-      p14_html: Les matchs joués par chaque joueur sont affichés sous forme d'éléments de liste. Les en-têtes sont <b>Scores du match, Points de match du joueur, Points de match de l'adversaire, Points totaux de l'adversaire</b>. Les matchs non joués sont également répertoriés.
-      p15: En cliquant sur une ligne de match, vous accédez à la page Modifier/Supprimer un match, et en cliquant sur un match non joué (administrateur uniquement), vous accédez à la page Nouveau score de match.
+      p14_html: >
+        Les matchs joués par chaque joueur sont affichés sous forme d'éléments de liste. Les en-têtes sont <b>Scores match</b>, <b>Points joueur</b>, <b>Points adversaire</b>, <b>Cumul adversaire</b>.<br>
+        Les matchs non joués sont également répertoriés.<br><br>
+        En cliquant sur une ligne de match, vous accédez à la page <b>Modifier/Supprimer un match</b>, et en cliquant sur un match non joué (administrateur uniquement), vous accédez à la page <b>Nouveau score</b> du match.
       table_view: Vue en Grille
       p16: Les matchs de chaque joueur sont affichés sous leur adversaire correspondant.
       p17_html: >
-        Le <span class= 'color-orange'>joueur connecté</span> apparaît en orange, et un lien vers <span class='color-tennis-blue'>Ma box</span> apparaît
+        Le joueur connecté apparaît en <span class='color-orange'>orange</span>, et un bouton <span class='color-tennis-blue'>Ma box</span> apparaît
         à gauche du lien de bascule vers la <span class='color-tennis-blue'>Vue en liste</span> ( <i class='fa-solid fa-list color-tennis-blue'></i> ).
       list_view: Vue en Liste
-      p19_html: Les matchs joués par chaque joueur sont affichés sous forme d'éléments de liste. Les en-têtes sont <b>Scores du match, Points de match du joueur, Points de match de l'adversaire, Points totaux de l'adversaire</b>.
+      p19_html: Les matchs joués par chaque joueur sont affichés sous forme d'éléments de liste. Les en-têtes sont <b>Scores match, Points joueur, Points adversaire, Cumul adversaire</b>.
       p20_html: >
-        Le <span class= 'color-orange'>joueur connecté</span> apparaît en orange, et un lien vers <span class='color-tennis-blue'>Ma box</span> apparaît
+        Le joueur connecté apparaît en <span class='color-orange'>orange</span>, et un bouton <span class='color-tennis-blue'>Ma box</span> apparaît
         à gauche du lien de bascule vers la <span class='color-tennis-blue'>Vue en grille</span> ( <i class='fa-regular fa-table-list color-tennis-blue'></i> ).
-      manage_my_box: Ma box
-      p22_html: Chacune de mes dates de matchs et les points des joueurs avec des liens tels que <span class='color-tennis-blue'>Afficher ma box</span>, <span class='color-tennis-blue'>Voir les résultats des matchs</ span> et <span class='color-tennis-blue'>Entrez un nouveau score</span>.
+      my_box: Ma box
+      p22_html: Chacune de mes dates de matchs et les points des joueurs avec des liens tels que <span class='color-tennis-blue'>Résultats de ma box</span>, <span class='color-tennis-blue'>Score du match</span> et <span class='color-tennis-blue'>Saisir un score</span>.
       p23: Lien vers la chatroom de la box.
       match_results: Affichage des résultats du match
       p24: "Détails d'un match joué:"
-      li05: date et heure du match, numéro du terrain,
-      li06: score, avec date et heure de saisie,
+      li05: date, heure du match, et numéro du terrain
+      li06: score, avec date et heure de saisie
       li07: gains du match et total des points.
       new_match_score: Nouveau score
       p25: Formulaire pour saisir les nouveaux détails du match.
       match_edit_score: Éditer le score
       p26: Formulaire pour modifier les détails du match ou supprimer le score.
+      chatrooms: Chatrooms
+      p27_html: >
+        La <b>chatroom #general</b>, accessible depuis le menu principal, est ouverte à tous les joueurs, quelque soit leur club.<br>
+        Les utilisateurs devront l'utiliser pour leur communication à portée générale, et devront faire preuve de modération.<br>
+        Une <b>chatroom de box</b> existe également pour chaque box du tournoi, accessible depuis la page <b>Ma Box</b>.<br><br>
+        Une couleur est attribuée aux messages, selon leur auteur:<br>
+      p28_html: >
+        La <b>chatroom #general</b> et les <b>chatroom de box</b> sont accessibles depuis le menu principal. La chatroom #general est ouverte à tous les joueurs, quelque soit leur club.<br>
+        Les utilisateurs devront l'utiliser pour leur communication à portée générale, et devront faire preuve de modération.<br>
+        Chaque <b>chatroom de box</b> dédiée à une box du tournoi, est accessible depuis la page <b>Ma Box</b> disponible aux joueurs.<br><br>
+        Une couleur est attribuée aux messages, selon leur auteur:<br>
+      li08_html: <span class='color-tennis-blue'>Ceux des joueurs du même club apparaîssent en bleu</span>
+      li09_html: <span class='color-tennis-aqua'>Ceux du Referee du même club apparaîssent en aqua</span>
+      li10_html: <span class= 'color-grey'>Ceux des joueurs des autres clubs apparaîssent en gris clair</span>
+      li11_html: <span class= 'color-black'>Ceux du Referee d'un autre club apparaîssent en gris foncé</span>
+      li12_html: <span class= 'color-tennis-red'>Ceux de l'admin apparaîssent en rouge</span>
+      p29: Les messages reçus apparaissent sur la gauche de l'écran, et les messages envoyés sur la droite.

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -161,17 +161,17 @@ nl:
       sitemap_title: Sitemap LeagueBox
       home: Home
       p01: Algemene presentatie van het Box League Toernooi
-      overview_rules: Toernooibeschrijving en regels
-      p03: Box League-regels uitgelegd
+      overview_rules: Toernooiregels
+      p03: Toernooibeschrijving en Box League-regels uitgelegd
       club_staff: Clubpersoneel
-      p05: Gegevens van de beheerder en de clubscheidsrechter
+      p05: Gegevens van de beheerder (admin) en de clubscheidsrechter (Referee)
       all_boxes: Boxen
       p07: "Presenteert alle boxen in één oogopslag voor elke speler:"
       li01: zijn naam
       li02: zijn ranking binnen het toernooi
       li03: het aantal gespeelde wedstrijden
       li04: accumulatie van punten
-      p08_html: "De <span class= 'color-orange'>verbonden speler</span> wordt oranje weergegeven."
+      p08_html: "De verbonden speler wordt <span class='color-orange'>oranje</span> weergegeven."
       p09a: Als u op een box klikt, komt u in de boxscheidsrechter-weergave.
       p09b: Als u op een vakje klikt, gaat u naar de rasterweergave.
       p10a_html: Naarmate het einde van de ronde nadert, verschijnt er een voettekstknop waarmee u <span class='color-tennis-aqua'>Maak de volgende ronde</span>.
@@ -179,20 +179,22 @@ nl:
       p11_html: Elke speler verschijnt van beste naar minst gerangschikt onder de kopjes <b>Speler, Ranglijst, Punten, Box, Wedstrijden </b>(gespeelde wedstrijden)<b>, Gewonnen </b>(gewonnen wedstrijden)<b>, Sets </b>(sets gespeeld)<b>, gewonnen </b>(sets gewonnen).
       p12: Door op een kop te klikken, rangschikken spelers zichzelf volgens die kop.
       referee_view: Box referee view
-      p14_html: Bekijk de pagina op <span class='color-tennis-blue'>Terug naar boven</span> en <span class='color-tennis-blue'>Alle boxen</span>.
-      p15: Als u op een wedstrijdregel klikt, komt u terecht op de pagina Wedstrijd bewerken/verwijderen. Als u op een ongespeelde wedstrijd klikt (alleen voor de beheerder), komt u terecht op de pagina Nieuwe wedstrijdscore.
+      p14_html: >
+        De door elke speler gespeelde wedstrijden worden weergegeven als lijstitems. De kopteksten zijn <b>Wedstrijdscores, Spelerpunten, Tegenstander punten, Tegenstander accumulatiepunten</b>.<br>
+        Als u op een wedstrijdregel klikt, komt u terecht op de pagina <b>Wedstrijd bewerken/verwijderen</b>.<br><br>
+        Als u op een ongespeelde wedstrijd klikt (alleen voor de beheerder), komt u terecht op de pagina <b>Nieuwe wedstrijdscore</b>.
       table_view: Box resultatenraster
       p16: De wedstrijden van elke speler worden weergegeven onder de bijbehorende tegenstander.
       p17_html:
-        De <span class= 'color-orange'>verbonden speler</span> wordt oranje weergegeven en er verschijnt een link naar <span class='color-tennis-blue'>Mijn box</span>
+        De verbonden speler wordt <span class='color-orange'>oranje</span> weergegeven en er verschijnt een <span class='color-tennis-blue'>Mijn box</span>-knop
         links van de schakellink naar de <span class='color-tennis-blue'>resultaten lijst</span> ( <i class='fa-solid fa-list color-tennis-blue'></i> ).
       list_view: Box resultaten lijst
-      p19_html: De gespeelde wedstrijden van elke speler worden weergegeven als lijstitems. Kopteksten zijn <b>Wedstrijdscores, Matchpunten van de speler, Matchpunten van de tegenstander, Totaal aantal punten van de tegenstander</b>.
+      p19_html: De gespeelde wedstrijden van elke speler worden weergegeven als lijstitems. Kopteksten zijn <b>Wedstrijdscores, Spelerpunten, Tegenstander punten, Tegenstander accumulatiepunten</b>.
       p20_html: >
-        De <span class= 'color-orange'>verbonden speler</span> wordt oranje weergegeven en er verschijnt een link naar <span class='color-tennis-blue'>Mijn box</span>
+        De verbonden speler wordt <span class='color-orange'>oranje</span> weergegeven en er verschijnt een <span class='color-tennis-blue'>Mijn box</span>-knop
         links van de schakellink naar de <span class='color-tennis-blue'>resultatenraster</span> ( <i class='fa-regular fa-table-list color-tennis-blue'></i>).
-      manage_my_box: Mijn box
-      p22_html: Al mijn wedstrijddata en spelerspunten met links zoals <span class='color-tennis-blue'>Bekijk mijn box</span>, <span class='color-tennis-blue'>Bekijk de wedstrijdresultaten</span> en <span class='color-tennis-blue'>Voer nieuwe score in</span>.
+      my_box: Mijn box
+      p22_html: Al mijn wedstrijddata en spelerspunten met links zoals <span class='color-tennis-blue'>Mijn boxresultaten</span>, <span class='color-tennis-blue'>Wedstrijdscore</span> en <span class='color-tennis-blue'>Voer een score in</span>.
       p23: Link naar de box-chatroom.
       match_results: Wedstrijdresultaten bekijken
       p24: "Details van een gespeelde wedstrijd:"
@@ -203,3 +205,20 @@ nl:
       p25: Formulier om nieuwe wedstrijdgegevens in te voeren.
       match_edit_score: Wedstrijdbewerkingsscore
       p26: Formulier om wedstrijddetails te wijzigen of score te verwijderen.
+      chatrooms: Chatrooms
+      p27_html: >
+        De <b>#general chatroom</b>, toegankelijk vanuit het hoofdmenu, is open voor alle spelers, ongeacht hun club.<br>
+        Gebruikers moeten het gebruiken voor hun algemene communicatie en moeten gematigd zijn.<br>
+        Er is ook een <b>box-chatroom</b> voor elke toernooibox, toegankelijk via de pagina <b>Mijn box</b>.<br><br>
+        Aan berichten wordt een kleur toegekend, volgens hun auteur:<br>
+      p28_html: >
+        De <b>#general chatroom</b> en de <b>boxchatrooms</b> zijn toegankelijk via het hoofdmenu. De #general chatroom is open voor alle spelers, ongeacht hun club.<br>
+        Gebruikers moeten het gebruiken voor hun algemene communicatie en moeten gematigd zijn.<br>
+        Elke <b>box-chatroom</b> die aan een box in het toernooi is gewijd, is toegankelijk via de <b>Mijn Box</b>-pagina die beschikbaar is voor spelers.<br><br>
+        Aan berichten wordt een kleur toegekend, volgens hun auteur:<br>
+      li08_html: <span class='color-tennis-blue'>Die van spelers van dezelfde club verschijnen in het blauw</span>
+      li09_html: <span class='color-tennis-aqua'>Die van de scheidsrechter van dezelfde club verschijnen in aqua</span>
+      li10_html: <span class= 'color-grey'>Die van spelers van andere clubs verschijnen in lichtgrijs</span>
+      li11_html: <span class= 'color-black'>Die van de scheidsrechter van een andere club verschijnen in donkergrijs</span>
+      li12_html: <span class= 'color-tennis-red'>Die van de beheerder verschijnen in het rood</span>
+      p29: Ontvangen berichten verschijnen aan de linkerkant van het scherm en verzonden berichten aan de rechterkant.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     resources :boxes, only: [:index, :show]
     get "boxes-list/:id", to: "boxes#show_list", as: "box_list"
     get "boxes_referee/:id", to: "boxes#show_referee", as: "box_referee"
-    get "manage_my_box/:id", to: "boxes#manage_my_box", as: "manage_my_box"
+    get "my_box/:id", to: "boxes#my_box", as: "my_box"
 
     resources :matches, only: [:show, :edit, :update, :new, :create, :destroy]
     resources :user_box_scores, only: [:index, :new, :create]
@@ -20,7 +20,8 @@ Rails.application.routes.draw do
     resources :chatrooms, only: :show do
       resources :messages, only: :create
     end
-    resources :contacts, only: [:new, :create ]
+    # resources :contacts, only: [:new, :create ]
+    resources :contacts, only: [:create ]
     get "/contacts", to: "contacts#new", as: "contact"
     get "contacts/sent"
   end


### PR DESCRIPTION
- added a button in Boxes index for referee to request new round
the feature handled in the contact form:
when invoking the form for this feature, one file, and one file only, must be attached (containing the list of players for the next round): since the regular contact_us feature uses the same view, I included some tests
I discovered that when multiple : true is set  for file_field, required: true is always true since the output is an empty array if no files are attached. I therefore use two routes, one with multiple : true with no required condition (contact_us feature), and one without multiple : true and with required: true (new round request feature); in the contact model, I added a validate: { presence: true } for the files attribute which could be omitted. 
In the strong params, I need to allow for the two possible files class outputs array and normal
params.require(:contact).permit(..., :files, files: [])
- translated error messages in the contact form