### PR TITLE
round numbering in chatroom names

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -32,21 +32,23 @@
   &:hover {
     box-shadow: 0 0 15px 5px rgba(0,0,0,0.1);
     // background: #3e8e41;
-    background: #7f7f7f;
+    // background: #7f7f7f;
+    background: linear-gradient(180deg, #7f7f7f 0%, $tennis-green 100%);
     color: $tennis-blue;
   }
 }
 
-.btn-blue {
+.btn-yellow {
   // background: $tennis-blue;
-  background: linear-gradient(180deg, $tennis-beige 0%, $tennis-aqua 100%);
+  background: linear-gradient(180deg, $yellow 0%, $tennis-beige 100%);
   // color: white;
   color: $tennis-blue;
 
   &:hover {
     box-shadow: 0 0 15px 5px rgba(0,0,0,0.1);
-    background: #7f7f7f;
-    color: white;
+    // background: #7f7f7f;
+    background: linear-gradient(180deg, #7f7f7f 0%, $orange 100%);
+    color: $tennis-blue;
   }
 }
 
@@ -63,11 +65,11 @@
 
 .btn-aqua {
   background: $tennis-aqua;
-  color: white;
+  color: $tennis-green;
 
   &:hover {
     box-shadow: 0 0 15px 5px rgba(0,0,0,0.1);
-    background: rgb(145, 91, 150);
+    background: $tennis-blue;
     color: white;
   }
 }

--- a/app/assets/stylesheets/pages/_boxes.scss
+++ b/app/assets/stylesheets/pages/_boxes.scss
@@ -12,12 +12,12 @@
 }
 
 .box-width {
-  width: 80rem;
+  width: 85vw;
 }
 
 .grid-container {
 
-  padding: 50px;
+  padding: 20px;
 
   #grid-lines>.row>.grid-columns {
     height: 5.5rem;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,7 @@ class ApplicationController < ActionController::Base
     @general_chatroom = Chatroom.find_by(name: "general") || Chatroom.create(name: "general")
     # time_zone (dependency on gem tzinfo-data): used to convert UTC persisted times in local time
     @tz = TZInfo::Timezone.get("Europe/Paris")
+    @is_mobile = mobile_device?
   end
 
   # def after_sign_in_path_for(resource)
@@ -80,7 +81,7 @@ class ApplicationController < ActionController::Base
       # user belongs to a club (= is a player or a referee),
       # or admin has chosen a club in the clubs form (i.e. params[:club_name] is defined)
       @club = Club.find_by(name: params[:club_name]) if @club == @sample_club
-      @start_dates = @club.rounds.map(&:start_date).sort.reverse # dropdown in the form
+      @start_dates = @club.rounds.map(&:start_date).sort.reverse # dropdown in the select round form
       @round = params[:round_start] ? Round.find_by(start_date: params[:round_start].to_time, club_id: @club.id) : current_round(@club.id)
 
       @boxes = @round.boxes.sort
@@ -177,5 +178,9 @@ class ApplicationController < ActionController::Base
   def add_to_tieds(*players)
     players.each { |player| @tieds << player }
     @tieds.uniq!
+  end
+
+  def mobile_device?
+    request.user_agent =~ /Mobile|webOS/
   end
 end

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -52,7 +52,13 @@ class BoxesController < ApplicationController
         # If the assigned chatroom is still #general, or if this box has no chatroom yet,
         # we create a new chatroom here whith the name: "[Club name] - b[Box number]/R[Round id]"
         # it will NOT remain available to players when in the next round (a chatroom is round specific)
-        @chatroom = Chatroom.create(name: "#{@box.round.club.name} - B#{format('%02d', @box.box_number)}/R#{format('%02d', @box.round.id)}")
+        round_year = @box.round.start_date.year
+        rounds_ordered = Round.where('extract(year  from start_date) = ?', round_year)
+                              .where(club_id: @box.round.club)
+                              .order('start_date ASC')
+                              .map(&:id)
+        round_number = "#{round_year - (round_year / 100 * 100)}_#{format('%02d',rounds_ordered.index(@box.round.id) + 1)}"
+        @chatroom = Chatroom.create(name: "#{@box.round.club.name} - B#{format('%02d', @box.box_number)}/R#{round_number}")
         @box.update(chatroom_id: @chatroom.id)
       else
         @chatroom = @box.chatroom

--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -13,7 +13,7 @@ class ChatroomsController < ApplicationController
       # for the admin: all chatrooms; for a referee: only those from his own club + the #general chatroom
       if current_user == @admin
         @chatrooms = Chatroom.all
-      else
+      else # current_user is a Referee
         @chatrooms = Chatroom.select do |chatroom|
           box = chatroom.box
           club = box.round.club

--- a/app/views/boxes/_intro_lines.html.erb
+++ b/app/views/boxes/_intro_lines.html.erb
@@ -15,7 +15,7 @@
         <%= "Box #{box.box_number} - #{view_types[0]}" %>
       </div>
     </h3>
-    <span class="will-print"><%= image_tag "tennis_racket.png", alt: "Tennis racket", width: 50 %> League Box ©</span>
+    <span class="will-print"><%= image_tag "tennis_racket.png", alt: "Tennis racket", width: 50 %> LeagueBox ©</span>
     <% if @this_is_my_box %>
       <h5>
         <%= render "shared/fullname", user: current_user %>
@@ -30,7 +30,6 @@
 </div>
 
 <div class="dont-print">
-  <%= link_to t('print_btn'), '#', :onclick => 'window.print();return false;', class: "btn buttons-shape btn-green mb-3 dont-print"%>
   <% if @this_is_my_box %>
     <%= link_to t(".my_box_btn"), my_box_path(box), class: "btn buttons-shape btn-orange mb-3" %>
   <% end %>
@@ -41,21 +40,22 @@
       <% case params[:caller] %>
         <% when "R" %>
           <%# if table view was called from Referee view, link back to Referee view %>
-          <%= link_to box_referee_path, class: "btn buttons-shape btn-blue mb-3" do %>
+          <%= link_to box_referee_path, class: "btn buttons-shape btn-yellow mb-3" do %>
             <i class="fa-regular fa-list"></i><%= " #{t("boxes.switch")} #{t("boxes.referee_view")}" %>
           <% end %>
         <% else %>
           <%# if table view was called from list view, all boxes or league table, link back to list view %>
-          <%= link_to box_list_path, class: "btn buttons-shape btn-blue mb-3" do %>
+          <%= link_to box_list_path, class: "btn buttons-shape btn-yellow mb-3" do %>
             <i class="fa-regular fa-list"></i><%= " #{t("boxes.switch")} #{t("boxes.list_view")}" %>
           <% end %>
       <% end %>
     <% else %>
       <%# if in list view or in Referee view, link back to table view %>
-      <%= link_to box_path(caller: view_types[0]==t("boxes.list_view") ? "L" : "R"), class: "btn buttons-shape btn-blue mb-3" do %>
+      <%= link_to box_path(caller: view_types[0]==t("boxes.list_view") ? "L" : "R"), class: "btn buttons-shape btn-yellow mb-3" do %>
         <i class="fa-solid fa-table-cells"></i><%= " #{t("boxes.switch")} #{view_types[1]}" %>
       <% end %>
   <% end %>
 
-  <%= link_to t('.all_boxes_link'), boxes_path, class: "btn buttons-shape btn-blue mb-3" %>
+  <%= link_to t('.all_boxes_link'), boxes_path, class: "btn buttons-shape btn-yellow mb-3" %>
+  <%= link_to t('print_btn'), '#', :onclick => 'window.print();return false;', class: "btn buttons-shape btn-green mb-3 dont-print"%>
 </div>

--- a/app/views/boxes/index.html.erb
+++ b/app/views/boxes/index.html.erb
@@ -2,7 +2,7 @@
 <div class="container">
   <div class="one-liner">
     <h3><%= t '.all_box_title' %></h3>
-    <span class="will-print"><%= image_tag "tennis_racket.png", alt: "Tennis racket", width: 50 %> League Box ©</span>
+    <span class="will-print"><%= image_tag "tennis_racket.png", alt: "Tennis racket", width: 50 %> LeagueBox ©</span>
   </div>
   <% if @round %>
     <div class = "one-liner">

--- a/app/views/boxes/my_box.html.erb
+++ b/app/views/boxes/my_box.html.erb
@@ -19,11 +19,11 @@
           <!-- Back -->
           <% if @page_from %>
             <% parameters = "?round_start=#{@box.round.start_date}&club_name=#{@box.round.club.name}" %>
-            <%= link_to @page_from+parameters, class: "btn buttons-shape btn-blue" do %>
+            <%= link_to @page_from+parameters, class: "btn buttons-shape btn-yellow" do %>
               <i class="fa-solid fa-left-long"></i>
             <% end %>
           <% else %>
-            <%= link_to :back, class: "btn buttons-shape btn-blue" do %>
+            <%= link_to :back, class: "btn buttons-shape btn-yellow" do %>
               <i class="fa-solid fa-left-long"></i>
             <% end %>
           <% end %>
@@ -78,7 +78,7 @@
       <div class="frame-color-shape players frame-padding text-size">
         <h4><%= t '.chat_in_my_box' %></h4>
         <div class="buttons-wrap">
-          <%= link_to t(".access_chatroom_btn"), chatroom_path(@chatroom), class: "btn buttons-shape btn-blue text-size" %>
+          <%= link_to t(".access_chatroom_btn"), chatroom_path(@chatroom), class: "btn buttons-shape btn-yellow text-size" %>
         </div>
       </div>
     <% end %>
@@ -87,11 +87,11 @@
     <div class="buttons-wrap">
       <% if @page_from %>
         <% parameters = "?round_start=#{@box.round.start_date}&club_name=#{@box.round.club.name}" %>
-        <%= link_to "Back", @page_from+parameters, class: "btn buttons-shape btn-blue text-size" %>
+        <%= link_to "Back", @page_from+parameters, class: "btn buttons-shape btn-yellow text-size" %>
       <% else %>
-        <%# link_to "Back", "javascript:history.back()", class: "btn buttons-shape btn-blue" %>
-        <%= link_to "Back", :back, class: "btn buttons-shape btn-blue text-size" %>
-        <%= link_to "Back to top", "#", class: "btn buttons-shape btn-blue text-size" %>
+        <%# link_to "Back", "javascript:history.back()", class: "btn buttons-shape btn-yellow" %>
+        <%= link_to "Back", :back, class: "btn buttons-shape btn-yellow text-size" %>
+        <%= link_to "Back to top", "#", class: "btn buttons-shape btn-yellow text-size" %>
       <% end %>
     </div>
     -->

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -11,11 +11,15 @@ a chatroom is created in Box controller #my_box.
   >
     <br><div class="one-liner" style="width: 50%">
       <h3>Chatroom</h3>
-      <span class="will-print"><%= image_tag "tennis_racket.png", alt: "Tennis racket", width: 50 %> League Box ©</span>
+      <span class="will-print"><%= image_tag "tennis_racket.png", alt: "Tennis racket", width: 50 %> LeagueBox ©</span>
     </div>
     <h5  class="one-liner">
+      <div><%= render "shared/display_round", round: @chatroom.box.round %></div>
       #<%= t(".chatroom_title", chatroom: @chatroom.name) %>
-      <%= link_to t('print_btn'), '#', :onclick => 'window.print();return false;', class: "btn buttons-shape btn-green dont-print"%>
+      <div>
+        <%= link_to t('.back_btn'), :back, class: "btn buttons-shape btn-yellow" %>
+        <%= link_to t('print_btn'), '#', :onclick => 'window.print();return false;', class: "btn buttons-shape btn-green dont-print"%>
+      </div>
     </h5>
     <div class="frame-color-shape chatroom-frame">
         <!-- previous messages -->
@@ -55,8 +59,8 @@ a chatroom is created in Box controller #my_box.
 <% else %>
   <!-- referees and admin get to select a chatroom -->
   <div class="container">
-    <br><h3><%= t(".chatrooms_title", club: current_user.club.name) %></h3>
-    <div class="frame-color-shape players frame-padding text-size">
+    <br><h3><%= t(".chatrooms_title", club: current_user == @admin ? "" : current_user.club.name) %></h3>
+    <div class="players frame-padding text-size">
       <%= form_with url: chatroom_path, method: :get do |form| %>
         <%= form.label :chatroom, t(".chose_chatroom") %>
         &nbsp;&nbsp;&nbsp;&nbsp;<%= form.select :chatroom, @chatrooms.sort %>
@@ -68,6 +72,6 @@ a chatroom is created in Box controller #my_box.
 <br>
 <!--
 <div class="buttons-wrap dont-print">
-  <%= link_to t(".back_btn"), :back, class: "btn buttons-shape btn-blue" %>
+  <%= link_to t(".back_btn"), :back, class: "btn buttons-shape btn-yellow" %>
 </div>
 -->

--- a/app/views/matches/edit.html.erb
+++ b/app/views/matches/edit.html.erb
@@ -1,48 +1,49 @@
 <!-- admin/referee: edit or delete a match and dependent user_match_scores -->
 <div class="container">
-  <br>
-  <h3><%= t '.edit_match_title' %></h3>
+  <div class="one-liner">
+    <h3><%= t '.edit_match_title' %></h3>
+  </div>
+  <div class="one-liner">
+    <%= render "shared/display_club_round", round: @round %>
+  </div>
   <p><%= t '.p01' %></p>
 
   <% players = [@current_player, @opponent] %>
-  <br>
-  <div class="one-liner">
-    <div>
-      <h5>
-        <%= render "shared/fullname", user: @user_match_scores[0].user %><%= " vs " %>
-        <%= render "shared/fullname", user: @user_match_scores[1].user %>
-      </h5>
-    </div>
+  <div class="one-liner frame-margin-rl">
+    <h5>
+      <%= render "shared/fullname", user: @user_match_scores[0].user %><%= " vs " %>
+      <%= render "shared/fullname", user: @user_match_scores[1].user %>
+    </h5>
   </div>
 
   <%= form_for @match do |f| %>
-    <div class = "frame-color-shape frame-padding-no-top">
+    <div class = "frame-color-shape frame-margin-rl frame-padding">
       <br>
       <div class="row">
-        <div class="col-3"><%= f.label :court_id, t(".match_played") %></div>
+        <div class="col-4"><%= f.label :court_id, t(".match_played") %></div>
         <div class="col-1"><%= f.select :court_id, 1..10 %></div>
       </div>
       <br>
       <div class="row">
-        <div class="col-3"><%= t '.date_time' %></div>
+        <div class="col-4"><%= t '.date_time' %></div>
         <div class="col-3">
           <%= f.date_field(:time, min: @round.start_date, max: @end_select ) %>
-          <%= f.time_select(:time, start_hour: 8, end_hour: 19, minute_step: 30, :time_separator => "") %>
+          <%# f.time_select(:time, start_hour: 8, end_hour: 19, minute_step: 30, :time_separator => "") %>
         </div>
       </div>
       <br>
-      <div class="row">
-        <div class="col-3"></div>
-        <div class="col-1"><%= t '.set_1' %></div>
-        <div class="col-1"><%= t '.set_2' %></div>
-        <div class="col-1"><%= t '.tie_break' %></div>
-      </div>
+      <i><div class="row">
+        <div class="col-4"></div>
+        <div class="col-2"><%= t '.set_1' %></div>
+        <div class="col-2"><%= t '.set_2' %></div>
+        <div class="col-2"><%= t '.tie_break' %></div>
+      </div></i>
       <%= f.fields_for :user_match_scores do |user_match_score| %>
         <div class="row">
-          <div class="col-3"><%= render "shared/fullname", user: players[user_match_score.index] %></div>
-          <div class="col-1"><%= user_match_score.select :score_set1, 0..4 %></div>
-          <div class="col-1"><%= user_match_score.select :score_set2, 0..4 %></div>
-          <div class="col-1"><%= user_match_score.select :score_tiebreak,['Na']+(0..25).to_a %></div>
+          <div class="col-4"><%= render "shared/fullname", user: players[user_match_score.index] %></div>
+          <div class="col-2"><%= user_match_score.select :score_set1, 0..4 %></div>
+          <div class="col-2"><%= user_match_score.select :score_set2, 0..4 %></div>
+          <div class="col-2"><%= user_match_score.select :score_tiebreak,['Na']+(0..11).to_a %></div>
         </div>
       <% end %>
       <br>
@@ -66,9 +67,9 @@
       data: {turbo_method: :delete, turbo_confirm: t(".sure")} %>
       &nbsp;&nbsp;&nbsp;&nbsp;
       <% if current_user.role == "player" %>
-        <%= link_to t(".back_btn"), my_box_path(@match.box, page_from: my_box_path(@match.box)), class: "btn buttons-shape btn-blue" %>
+        <%= link_to t(".back_btn"), my_box_path(@match.box, page_from: my_box_path(@match.box)), class: "btn buttons-shape btn-yellow" %>
       <% else %>
-        <%= link_to t(".back_btn"), box_referee_path(@match.box, page_from: box_referee_path(@match.box)), class: "btn buttons-shape btn-blue" %>
+        <%= link_to t(".back_btn"), box_referee_path(@match.box, page_from: box_referee_path(@match.box)), class: "btn buttons-shape btn-yellow" %>
       <% end %>
 
     </div>

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -1,23 +1,23 @@
 <!-- player: enter a new match score-->
 <div class = "container" id="form">
-  <br>
-  <h3><%= t(".new_match_title") %></h3>
-  <p><%= t '.p01' %></p>
-
-  <br><%= render "shared/display_club_round", round: @round %>
-  <% players = [@current_player, @opponent] %>
-  <br>
   <div class="one-liner">
-    <div>
-      <h4>
-        <%= render "shared/fullname", user: @current_player %><%= " vs " %>
-        <%= render "shared/fullname", user: @opponent %>
-      </h4>
-    </div>
+    <h3><%= t(".new_match_title") %></h3>
+  </div>
+  <div class="one-liner">
+    <%= render "shared/display_club_round", round: @round %>
+  </div>
+  <%= t '.p01' %><br><br>
+
+  <% players = [@current_player, @opponent] %>
+  <div class="one-liner frame-margin-rl">
+    <h5>
+      <%= render "shared/fullname", user: @current_player %><%= " vs " %>
+      <%= render "shared/fullname", user: @opponent %>
+    </h5>
   </div>
 
   <%= form_for @match do |f| %>
-    <div class = "frame-color-shape frame-padding-no-top">
+    <div class = "frame-color-shape frame-margin-rl frame-padding">
       <br>
       <div class="row">
         <div class="col-3"><b><%= f.label :court_id, t(".match_played") %></b></div>
@@ -34,28 +34,27 @@
       </div>
       <br>
       <b><%= t '.score' %></b>
-      <div class="row">
-        <div class="col-2"><%= t '.player_1' %></div>
+      <i><div class="row">
+        <div class="col-3"><%= @is_mobile ? "" : t('.player_1') %></div>
         <div class="col-2"><%= t '.set_1' %></div>
         <div class="col-2"><%= t '.set_2' %></div>
         <div class="col-2"><%= t '.tie_break' %></div>
-        <div class="col-1"></div>
-        <div class="col-2"><%= t '.player_2' %></div>
-      </div>
-      <% scores = [[t('.input_score'), "0-4", "1-4", "2-4", "3-4", "4-3", "4-2", "4-1", "4-0"]] %>
-      <% score_tb = [[t('.input_score'),
-                    "0-10", "1-10", "2-10", "3-10", "4-10", "5-10", "6-10", "7-10", "8-10", "9-11 #{t('.and_more')}",
-                    "11-9 #{t('.and_more')}", "10-8", "10-7", "10-6", "10-5", "10-4", "10-3", "10-2", "10-1", "10-0" ]] %>
+        <div class="col-3"><%= @is_mobile ? "" : t('.player_2') %></div>
+      </div></i>
+      <% scores = [["#{ @is_mobile ? "---" : t('.input_score') }", "0-4", "1-4", "2-4", "3-4", "4-3", "4-2", "4-1", "4-0"]] %>
+      <% score_tb = [["---",
+                    "0-10", "1-10", "2-10", "3-10", "4-10", "5-10", "6-10", "7-10", "8-10", "9-11 #{ @is_mobile ? "+" : t('.and_more') }",
+                    "11-9 #{ @is_mobile ? "+" : t('.and_more') }", "10-8", "10-7", "10-6", "10-5", "10-4", "10-3", "10-2", "10-1", "10-0" ]] %>
       <%= f.fields_for :user_match_scores do |user_match_score| %>
         <div class="row">
-          <div class="col-2"><%= render "shared/fullname", user: players[user_match_score.index] %></div>
+          <div class="col-3"><%= render "shared/fullname", user: players[user_match_score.index] %></div>
           <div class="col-2"><%= user_match_score.select :score_set1, scores[user_match_score.index] %></div>
           <div class="col-2"><%= user_match_score.select :score_set2, scores[user_match_score.index] %></div>
           <div class="col-2"><%= user_match_score.select :score_tiebreak,score_tb[user_match_score.index] %></div>
-          <div class="col-1"></div>
-          <div class="col-2"><%= render "shared/fullname", user: players[1] %></div>
+          <div class="col-3 float-right"><%= render "shared/fullname", user: players[1] %></div>
         </div>
       <% end %>
+      <br>
       <%= hidden_field_tag(:player_id, @current_player.id) %>
       <%= hidden_field_tag(:opponent_id, @opponent.id) %>
       <%= hidden_field_tag(:round_start, @round.start_date) %>
@@ -63,14 +62,15 @@
       <%# hidden_field_tag(:page_from, @page_from) %>
     </div>
     <br>
+
     <div class="buttons-wrap">
       <%= f.submit t(".save_score_btn"), class: "btn buttons-shape btn-green" %>
       <%# f.submit t(".save_score_btn"), class: "btn buttons-shape btn-green" %>
       &nbsp;&nbsp;&nbsp;&nbsp;
       <% if current_user.role == "player" %>
-        <%= link_to t(".back_btn"), my_box_path(@box, page_from: my_box_path(@box)), class: "btn buttons-shape btn-blue" %>
+        <%= link_to t(".back_btn"), my_box_path(@box, page_from: my_box_path(@box)), class: "btn buttons-shape btn-yellow" %>
       <% else %>
-        <%= link_to t(".back_btn"), box_referee_path(@box, page_from: box_referee_path(@box)), class: "btn buttons-shape btn-blue" %>
+        <%= link_to t(".back_btn"), box_referee_path(@box, page_from: box_referee_path(@box)), class: "btn buttons-shape btn-yellow" %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/matches/new2.html.erb
+++ b/app/views/matches/new2.html.erb
@@ -65,9 +65,9 @@
       <%= f.submit t(".save_score_btn"), class: "btn buttons-shape btn-green" %>
       &nbsp;&nbsp;&nbsp;&nbsp;
       <% if current_user.role == "player" %>
-        <%= link_to t(".back_btn"), my_box_path(@box, page_from: my_box_path(@box)), class: "btn buttons-shape btn-blue" %>
+        <%= link_to t(".back_btn"), my_box_path(@box, page_from: my_box_path(@box)), class: "btn buttons-shape btn-yellow" %>
       <% else %>
-        <%= link_to t(".back_btn"), box_referee_path(@box, page_from: box_referee_path(@box)), class: "btn buttons-shape btn-blue" %>
+        <%= link_to t(".back_btn"), box_referee_path(@box, page_from: box_referee_path(@box)), class: "btn buttons-shape btn-yellow" %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -46,6 +46,6 @@
   </div>
   <br>
   <div class="buttons-wrap">
-    <%= link_to t(".back_btn"), my_box_path(@match.box), class: "btn buttons-shape btn-blue" %>
+    <%= link_to t(".back_btn"), my_box_path(@match.box), class: "btn buttons-shape btn-yellow" %>
   </div>
 </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -37,7 +37,7 @@ style in stylessheet/pages/_chatroom.scss and in app/views/layouts/application.h
         <% sender += render "shared/fullname", user: message.user %>
         <% color_name = message.user.club == current_user.club ? "color-tennis-aqua" : "color-black" %>
       <% when "admin" %>
-        <% sender += " League Box website admin"  %>
+        <% sender += " LeagueBox © admin"  %>
         <% color_name = "color-tennis-red" %>
       <% end %>
       <% sender += " #{message.user.role}"  %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -37,7 +37,7 @@
 
   <br><div class = "buttons-wrap">
     <% if current_user == @admin %>
-      <%= link_to t('.create_club_btn'), new_user_box_score_path, class: "btn buttons-shape btn-aqua" %>
+      <%= link_to t('.add_club_btn'), new_user_box_score_path, class: "btn buttons-shape btn-aqua" %>
     <% end %>
   </div>
 </div>

--- a/app/views/pages/rules.html.erb
+++ b/app/views/pages/rules.html.erb
@@ -1,4 +1,8 @@
-<div class="dont-print"><%= render "shared/image_front" %></div>
+<% if !@is_mobile %>
+  <div class="dont-print"><%= render "shared/image_front" %></div>
+<% else %>
+  <br>
+<% end %>
 
 <div class="container">
   <div class="frame-color-shape frame-margin-rl frame-padding text-size dont-print">
@@ -13,7 +17,7 @@
        data-toggle-hide-rules-value="<%= t '.btn_hide_rules' %>">
     <div class = "buttons-wrap dont-print">
       <button data-action="click->toggle#toggleRules" data-toggle-target="toggler"
-        class="btn buttons-shape btn-blue text-size"><%= t '.btn_display_rules' %>
+        class="btn buttons-shape btn-yellow text-size"><%= t '.btn_display_rules' %>
       </button>
       <span class="d-none" data-toggle-target="togglableButton">
         <%= link_to t('print_btn'), '#', :onclick => 'window.print();return false;', class: "btn buttons-shape btn-green text-size ms-2"%>
@@ -71,15 +75,15 @@
       <h5><%= t '.box_league_ranking' %></h5>
         <p><%= t '.p25' %></p>
         <ol>
-          <% (13..16).each do |i| %>
+          <% (13..15).each do |i| %>
             <li><%= t ".li#{format '%02d',i}" %></li>
           <% end %>
         </ol>
       <h5><%= t '.promotion_relegation' %></h5>
         <p><%= t '.p26' %></p>
         <ul>
+          <li><%= t '.li16' %></li>
           <li><%= t '.li17' %></li>
-          <li><%= t '.li18' %></li>
         </ul>
       <h5><%= t '.new_entrants' %></h5>
         <p><%= t '.p27' %></p>
@@ -87,36 +91,39 @@
         <p><%= t '.p28' %></p>
       <h5><%= t '.no_show' %></h5>
         <p><%= t '.p29' %></p>
+        <ul>
+          <% (18..20).each do |i| %>
+            <li><%= t ".li#{format '%02d',i}" %></li>
+          <% end %>
+        </ul>
+      <h5><%= t '.retire_from_match' %></h5>
         <p><%= t '.p30' %></p>
         <p><%= t '.p31' %></p>
-      <h5><%= t '.retire_from_match' %></h5>
-        <p><%= t '.p32' %></p>
-        <p><%= t '.p33' %></p>
         <i>
-          <p><%= t '.p34' %></p>
-          <p><%= t '.p35' %></p>
+          <p><%= t '.p32' %></p>
+          <p><%= t '.p33' %></p>
         </i>
       <h5><%= t '.withdrawing' %></h5>
-        <p><%= t '.p36' %></p>
-        <p><%= t '.p37' %></p>
+        <p><%= t '.p34' %></p>
+        <p><%= t '.p35' %></p>
       <h5><%= t '.walk_overs' %></h5>
-        <p><%= t '.p38' %></p>
+        <p><%= t '.p36' %></p>
         <ul>
-          <li><%= t '.li19' %></li>
-          <li><%= t '.li20' %></li>
-          <li><%= t '.li21' %></li>
+          <% (21..23).each do |i| %>
+            <li><%= t ".li#{format '%02d',i}" %></li>
+          <% end %>
         </ul>
       <h5><%= t '.deadline_extensions' %></h5>
+        <p><%= t '.p37' %></p>
+        <p><%= t '.p38' %></p>
         <p><%= t '.p39' %></p>
-        <p><%= t '.p40' %></p>
-        <p><%= t '.p41' %></p>
       <h5><%= t '.disputes' %></h5>
       <% if @referee %>
         <% mailto = t(".mail_to_referee_html", referee_name: "#{@referee.first_name} #{@referee.last_name}", referee_email: @referee.email) %>
       <% else %>
         <% mailto = t(".mail_to_admin_html", admin_email: @admin.email) %>
       <% end %>
-      <p><%= t(".p42_html", mailto: mailto) %></p>
+      <p><%= t(".p40_html", mailto: mailto) %></p>
 
       <button  data-action="click->toggle#scrollToTop" data-toggle-target="topButton"
         class="btn buttons-shape btn-beige top-button d-none"><i class="fa-solid fa-up-long"></i>

--- a/app/views/pages/sitemap.html.erb
+++ b/app/views/pages/sitemap.html.erb
@@ -1,4 +1,8 @@
-<%= render "shared/image_front" %>
+<% if !@is_mobile %>
+  <div class="dont-print"><%= render "shared/image_front" %></div>
+<% else %>
+  <br>
+<% end %>
 
 <div class="container" data-controller="toggle">
   <div class="frame-color-shape frame-margin-rl frame-padding text-size box-scroller"

--- a/app/views/pages/staff.html.erb
+++ b/app/views/pages/staff.html.erb
@@ -1,5 +1,8 @@
-
-<%= render "shared/image_front" %>
+<% if !@is_mobile %>
+  <div class="dont-print"><%= render "shared/image_front" %></div>
+<% else %>
+  <br>
+<% end %>
 <div class="container">
   <div class="frame-color-shape frame-padding">
     <%= render "shared/staff", from:"pages" %>

--- a/app/views/rounds/new.html.erb
+++ b/app/views/rounds/new.html.erb
@@ -44,7 +44,7 @@
             <div class="buttons-wrap">
               <div class="box-title"><%= f.submit t(".create_round_btn"), class: "btn buttons-shape btn-green" %></div>
               &nbsp;&nbsp;&nbsp;&nbsp;
-              <%= link_to "Back", :back, class: "btn buttons-shape btn-blue" %>
+              <%= link_to "Back", :back, class: "btn buttons-shape btn-yellow" %>
             </div>
           </div>
         </div>

--- a/app/views/shared/_display_club_round.html.erb
+++ b/app/views/shared/_display_club_round.html.erb
@@ -2,6 +2,6 @@
 <div class="header-flex">
   <div><h4><%= round.club.name %></h4></div>
   <div style="width: 20px"></div>
-  <div><%= render "shared/round", round: round %></div>
+  <div><%= render "shared/display_round", round: round %></div>
 
 </div>

--- a/app/views/shared/_display_round.html.erb
+++ b/app/views/shared/_display_round.html.erb
@@ -1,3 +1,3 @@
 <%# partial: display round start date and end date %>
 <%# t(".round_period", start: round.start_date.strftime("%d %b"), end: round.end_date.strftime("%d %b %y")) %>
-<%= t(".round_period", start: l(round.start_date, format: :ddmmmyy_date), end: l(round.end_date, format: :ddmmmyy_date)) %>
+<%= t(".round_period", start: l(round.start_date, format: :ddmmm_date), end: l(round.end_date, format: :ddmmmyy_date)) %>

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,6 +1,6 @@
 <% if notice %>
   <%# <div class="alert alert-info alert-dismissible fade show m-1" role="alert"> %>
-  <div class="btn buttons-shape btn-blue alert" role="alert">
+  <div class="btn buttons-shape btn-yellow alert" role="alert">
     <%= notice %>
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
     </button>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="footer">
   <div class="footer-links">
     <a href="#"><i class="fab fa-github"></i></a>
-    League Box ©
+    LeagueBox ©
     <%# <a href="#"><i class="fab fa-instagram"></i></a>
     <a href="#"><i class="fab fa-facebook"></i></a>
     <a href="#"><i class="fab fa-twitter"></i></a>
@@ -15,7 +15,7 @@
 
   <div class="footer-links">
     <div class="footer-brand"><%= image_tag "tennis_racket.png" %>
-      League Box ©
+      LeagueBox ©
     </div>
   </div>
 </div>

--- a/app/views/shared/_image_front.html.erb
+++ b/app/views/shared/_image_front.html.erb
@@ -1,5 +1,5 @@
 <!-- inlay image from the presentation view pages (home, rules, staff and sitemap) and contact (sent) -->
 <div class="image-front"
     style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= image_path 'social_tennis.jpg' %>')">
-  <div class="font-black image-front-text"><h1><b><%= @club.name.capitalize %> League Box</b></h1></div>
+  <div class="font-black image-front-text"><h1><b><%= current_user == @admin ? "" : @club.name.capitalize %> LeagueBox</b></h1></div>
 </div><br>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -17,7 +17,7 @@
       <ul class="navbar-nav me-auto">
         <li class="nav-item time-color top-bottom-padding">
           <% if user_signed_in? && @round %>
-            <%= render "shared/round", round: @round %>
+            <%= render "shared/display_round", round: @round %>
           <% end %>
         </li>
 

--- a/app/views/shared/_navbar_language.html.erb
+++ b/app/views/shared/_navbar_language.html.erb
@@ -1,6 +1,10 @@
 <%# partial: dropdown language list from the navbar %>
+
 <li class="nav-item dropdown">
-  <a href="#" class="nav-link" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa-solid fa-globe"></i></a>
+  <a href="#" class= "nav-link" data-bs-toggle="dropdown" aria-expanded="false">
+    <i class="fa-solid fa-globe"></i>
+    <%= locale %>
+  </a>
   <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
     <%# link_to 'EN', {controller: controller_name, action: action_name, locale: :en}, {class: "dropdown-item"} %>
     <%= link_to "EN", request.params.except(:commit).merge(locale: :en), class: "dropdown-item" %>

--- a/app/views/shared/_select_club_round.html.erb
+++ b/app/views/shared/_select_club_round.html.erb
@@ -13,7 +13,7 @@
         <!-- name: "" to get rid of the name attribute, so commit does not appear in the url -->
         &nbsp;&nbsp;&nbsp;&nbsp;<%= form.submit t('.confirm_btn'), class: "btn buttons-shape btn-green", name: "" %>
         &nbsp;&nbsp;&nbsp;&nbsp;
-        <%= link_to t('.back_btn'), :back, class: "btn buttons-shape btn-blue" %>
+        <%= link_to t('.back_btn'), :back, class: "btn buttons-shape btn-yellow" %>
       <% end %>
     <% end %>
   <% end %>
@@ -28,14 +28,4 @@
   <!-- for players and referees: display the round form IF a club is already set -->
 
   <%= render "shared/select_round", fallback_path: fallback_path, label: t('.select_round_start') %>
-  <!--
-  <%= form_with url: fallback_path, method: :get do |form| %>
-    <%= form.label :round_start, t('.select_round_start') %>
-    <%= form.select :round_start, @start_dates, :selected => params[:round_start] %>&nbsp;&nbsp;&nbsp;&nbsp;
-    <%= hidden_field_tag(:club_name, @club.name) %>
-    <%= form.submit t('.confirm_btn'), class: "btn buttons-shape btn-green", name: "" %>
-    &nbsp;&nbsp;&nbsp;&nbsp;
-    <%= link_to t('.back_btn'), :back, class: "btn buttons-shape btn-blue" %>
-  <% end %>
-  -->
 <% end %>

--- a/app/views/user_box_scores/_buttons.html.erb
+++ b/app/views/user_box_scores/_buttons.html.erb
@@ -8,12 +8,6 @@
       method: :get,
       onclick: 'JavaScript:location.reload(true);',
       class: "btn buttons-shape btn-green mb-3 dont-print text-size" %>
-  <%= link_to t('.to_csv_btn'),
-      user_box_scores_path(to_csv: true, round_start: round.start_date, club_name: round.club.name),
-      method: :get,
-      data: { turbo: "false" },
-      onclick: 'JavaScript:location.reload(true);',
-      class: "btn buttons-shape btn-green mb-3 dont-print text-size" %>
-  <%= link_to 'Download', download_path(round_start: round.start_date, club_name: round.club.name),
+  <%= link_to t('.to_csv_btn'), csv_path(round_start: round.start_date, club_name: round.club.name),
       class: "btn buttons-shape btn-green mb-3 dont-print text-size" %>
 </div>

--- a/app/views/user_box_scores/_table_data.html.erb
+++ b/app/views/user_box_scores/_table_data.html.erb
@@ -13,8 +13,8 @@
           <div class="col-1 top-bottom-padding"><%= "# #{user_box_score.rank}" %></div>
           <div class="col-1 top-bottom-padding"><%= t("pts", count: user_box_score.points) %></div>
           <div class="col-1 top-bottom-padding"><%= "#{user_box_score.box.box_number}" %></div>
-          <div class="col-2 top-bottom-padding"><%= t(".matches", count: user_box_score.games_played) %></div>
-          <div class="col-2 top-bottom-padding"><%= t(".matches", count: user_box_score.games_won) %></div>
+          <div class="col-1 top-bottom-padding"><%= t(".matches", count: user_box_score.games_played) %></div>
+          <div class="col-1 top-bottom-padding"><%= t(".matches", count: user_box_score.games_won) %></div>
           <div class="col-1 top-bottom-padding"><%= t(".sets", count: user_box_score.sets_played) %></div>
           <div class="col-1 top-bottom-padding"><%= t(".sets", count: user_box_score.sets_won) %></div>
           <% if current_user.role == "admin" || current_user.role == "referee" %>

--- a/app/views/user_box_scores/_table_headers.html.erb
+++ b/app/views/user_box_scores/_table_headers.html.erb
@@ -5,7 +5,7 @@
 <div class="col-1"><%=render "header_to_link", header: t('.rank_header'), direction: topdown.reverse%></div>
 <div class="col-1"><%=render "header_to_link", header: t('.points_header'), direction: topdown%></div>
 <div class="col-1"><%=render "header_to_link", header: t('.box_header'), direction: topdown.reverse%></div>
-<div class="col-2"><%=render "header_to_link", header: t('.matches_played_header'), direction: topdown%></div>
-<div class="col-2"><%=render "header_to_link", header: t('.matches_won_header'), direction: topdown%></div>
+<div class="col-1"><%=render "header_to_link", header: t('.matches_played_header'), direction: topdown%></div>
+<div class="col-1"><%=render "header_to_link", header: t('.matches_won_header'), direction: topdown%></div>
 <div class="col-1"><%=render "header_to_link", header: t('.sets_played_header'), direction: topdown%></div>
 <div class="col-1"><%=render "header_to_link", header: t('.sets_won_header'), direction: topdown%></div>

--- a/app/views/user_box_scores/_top_line.html.erb
+++ b/app/views/user_box_scores/_top_line.html.erb
@@ -1,14 +1,14 @@
 <% if params["sort"] %>
   <% params["sort"] = nil  %>
   <%# <p class="stick-rules dont-print text-size"> %>
-  <p class="<%= browser_device_mobile ? "" : "stick-rules " %> dont-print text-size">
+  <p class="<%= is_mobile ? "" : "stick-rules " %> dont-print text-size">
     <%= link_to t(".top_line_html"),
         user_box_scores_path(round_start: round.start_date, club_name: round.club.name),
         class: "btn buttons-shape btn-top-line no-padding-no-border" %>
   </p>
 <% else %>
   <%# <p class="stick-rules dont-print text-size"> %>
-  <p class="<%= browser_device_mobile ? "" : "stick-rules " %> dont-print text-size">
+  <p class="<%= is_mobile ? "" : "stick-rules " %> dont-print text-size">
     <%= t '.top_line_html' %>
   </p>
   <div class="photo-wrap frame-color-shape frame-padding text-size dont-print">

--- a/app/views/user_box_scores/index.html.erb
+++ b/app/views/user_box_scores/index.html.erb
@@ -1,13 +1,13 @@
 <!-- index page: league table -->
 <div class="container" data-controller="toggle"
-     data-toggle-screen-type-value="<%= @browser_device_mobile ? "mobile" : "widescreen" %>">
+     data-toggle-screen-type-value="<%= @is_mobile ? "mobile" : "widescreen" %>">
   <br>
   <div class="one-liner">
     <h3><%= t '.league_table_title' %></h3>
     <!-- the following line will display when printing the page -->
     <span class="will-print one-liner">
       <div><%= image_tag "tennis_racket.png", alt: "Tennis racket", width: 50 %></div>
-      <div>League Box ©</div>
+      <div>LeagueBox ©</div>
       <div><%= "#{l(Time.now, format: :wwwddmmm_date)}" %>&nbsp;&nbsp<%= "#{l(Time.now, format: :hhmm_time)}" %></div>
     </span>
   </div>
@@ -15,14 +15,14 @@
     <div class="text-size">
       <div class="one-liner">
         <%= render "shared/display_club_round", round: @round,
-                                                mobile_screen: @browser_device_mobile ? true : false,
+                                                mobile_screen: @is_mobile ? true : false,
                                                 fallback_path: user_box_scores_path %>
         <%= render "shared/select_round", fallback_path: user_box_scores_path %>
       </div>
       <% if !@render_to_text %>
         <%# exclude buttons and top line from exporting to text (in user_box_score index) %>
         <br><%= render 'buttons', round: @round %>
-        <%= render 'top_line', round: @round, browser_device_mobile: @browser_device_mobile %>
+        <%= render 'top_line', round: @round, is_mobile: @is_mobile %>
       <% end %>
       <%= render 'league_table' %>
     </div>

--- a/app/views/user_box_scores/new.html.erb
+++ b/app/views/user_box_scores/new.html.erb
@@ -44,8 +44,8 @@ players are allocated in boxes by id in descending order  -->
       </div><br>
       <div class="buttons-wrap">
         <%= submit_tag t('.submit_btn'), class: "btn buttons-shape btn-green" %>
-        <%# link_to "Back", "javascript:history.back()", class: "btn buttons-shape btn-blue" %>
-        <%= link_to t('.back'), :back, class: "btn buttons-shape btn-blue" %>
+        <%# link_to "Back", "javascript:history.back()", class: "btn buttons-shape btn-yellow" %>
+        <%= link_to t('.back'), :back, class: "btn buttons-shape btn-yellow" %>
       </div>
     <% end %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  print_btn: ⎷ Print
+  print_btn: Print
   points:
     zero: 0 points
     one: 1 point
@@ -47,6 +47,7 @@ en:
     formats:
       default: "%Y-%m-%d"
       mmmyy_date: "%b %y"
+      ddmmm_date: "%d %b"
       ddmmmyy_date: "%d %b %y"
   time:
     formats:
@@ -61,7 +62,7 @@ en:
       wwwddmmm_at_hhmm: "%a %-d %b, %H:%M"
       wwwddmmmyy_at_hhmm: "%A %-d %b %Y, %H:%M"
 fr:
-  print_btn: ⎷ Imprimer
+  print_btn: Imprimer
   points:
     zero: 0 point
     one: 1 point
@@ -80,6 +81,7 @@ fr:
       short: "%e %b"
       long: "%e %B %Y"
       mmmyy_date: "%b %y"             # avr. 23
+      ddmmm_date: "%d %b"             # 30 avr.
       ddmmmyy_date: "%d %b %y"        # 30 avr. 23
     day_names: [dimanche, lundi, mardi, mercredi, jeudi, vendredi, samedi]
     abbr_day_names: [dim, lun, mar, mer, jeu, ven, sam]
@@ -105,7 +107,7 @@ fr:
     am: 'am'
     pm: 'pm'
 nl:
-  print_btn: ⎷ Afdrukken
+  print_btn: Afdrukken
   points:
     zero: 0 punten
     one: 1 punt
@@ -125,6 +127,7 @@ nl:
       long: "%e %B %Y"
       only_day: "%e"
       mmmyy_date: "%b %y"
+      ddmmm_date: "%d %b"
       ddmmmyy_date: "%d %b %y"
     day_names: [zondag, maandag, dinsdag, woensdag, donderdag, vrijdag, zaterdag]
     abbr_day_names: [zon, maa, din, woe, don, vri, zat]

--- a/config/locales/views/boxes/en.yml
+++ b/config/locales/views/boxes/en.yml
@@ -16,7 +16,7 @@ en:
       all_box_title: All boxes
       intro: "At a glance, see <b>all players name, their ranking, <b>number of played games, and their cumulated box points</b><br />"
       message_box_pop: <b>Box columns:</b><br />Player name, rank,<br />nb of games played, box points earned.<br /><br />Click on a box to view match details
-      create_round_btn: ⎷ Create the next round
+      create_round_btn: Create the next round
       request_round_btn: Request the admin the next round
     my_box:
       my_box_results: My scores

--- a/config/locales/views/chatrooms/fr.yml
+++ b/config/locales/views/chatrooms/fr.yml
@@ -14,6 +14,6 @@ fr:
       back_btn: ←
       chose_chatroom: "Choisir une chatroom: "
       confirm_btn: ⎷ Confirmer
-      chatrooms_title: "Chatrooms de %{club}"
+      chatrooms_title: "Chatrooms %{club}"
       no_access_flash: Vous n'avez pas accès à cette chatroom
       no_chatroom_flash: Cette chatroom n'existe pas

--- a/config/locales/views/chatrooms/nl.yml
+++ b/config/locales/views/chatrooms/nl.yml
@@ -14,6 +14,6 @@ nl:
       back_btn: ←
       chose_chatroom: "Kies een chatroom: "
       confirm_btn: ⎷ Bevestigen
-      chatrooms_title: "Chatrooms van %{club}"
+      chatrooms_title: "Chatrooms %{club}"
       no_access_flash: U heeft geen toegang tot deze chatroom
       no_chatroom_flash: Deze chatroom bestaat niet

--- a/config/locales/views/contacts/en.yml
+++ b/config/locales/views/contacts/en.yml
@@ -31,7 +31,7 @@ en:
     sent:
       sent_title: Message sent!
       p01_html: Thank you for your message. Your <b>admin</b> will get back to you soon.
-      p02: In the meantime, 🎾 keep playing your league box matches! 🎾
+      p02: In the meantime, 🎾 keep playing your LeagueBox matches! 🎾
       p03: In the meantime, 🎾 visit our Tournament rules pages! 🎾
       p04_html: >
         Thank you for requesting a new round creation for %{club_name}.<br>

--- a/config/locales/views/matches/en.yml
+++ b/config/locales/views/matches/en.yml
@@ -7,12 +7,12 @@ en:
       p01: Update or delete an existing match score
       match_played: "Court number: "
       date_time: "Match played on:"
-      set_1: Set 1
-      set_2: Set 2
-      tie_break: Tie-break
-      submitted: "Current score submitted on %{date} by %{player}."
-      update_score_btn: ⎷ Update score
-      delete_score_btn: x Delete score
+      set_1: set 1
+      set_2: set 2
+      tie_break: tiebreak
+      submitted: "Score submitted on %{date} by %{player}."
+      update_score_btn: ⎷ Update
+      delete_score_btn: x Delete
       sure: Are you sure?
       back_btn: ←
     new:
@@ -23,12 +23,12 @@ en:
       score: "Match score:"
       player_1: Player 1
       player_2: Player 2
-      set_1: Set 1
-      set_2: Set 2
-      tie_break: Tie-break
-      input_score: choose a score
-      and_more: and more
-      save_score_btn: ⎷ Save score
+      set_1: set 1
+      set_2: set 2
+      tie_break: tiebreak
+      input_score: input score
+      and_more: and +
+      save_score_btn: ⎷ Save
       back_btn: ←
       round_not_started_flash: Round has not started yet.
     show:

--- a/config/locales/views/matches/fr.yml
+++ b/config/locales/views/matches/fr.yml
@@ -4,30 +4,30 @@ fr:
       winner: "Vainqueur:"
     edit:
       edit_match_title: Editer un score
-      p01: Editer ou supprimer un score déjà saisi
+      p01: Editer ou supprimer un score existant
       match_played: "Court nº:"
       date_time: "Match joué le:"
-      set_1: 1er set
-      set_2: 2ème set
-      tie_break: Tie-break
+      set_1: set 1
+      set_2: set 2
+      tie_break: tiebreak
       submitted: "Score entré %{date} par %{player}."
       update_score_btn: ⎷ Valider
-      delete_score_btn: x Supprimer le score
+      delete_score_btn: x Supprimer
       sure: Confirmez-vous?
       back_btn: ←
     new:
       new_match_title: Nouveau score
-      p01: Saisir un nouveau score
+      p01: Soumettre un nouveau score
       match_played: "Court nº:"
       date_time: "Match joué le:"
       score: "Score du match:"
       player_1: Joueur 1
       player_2: Joueur 2
-      set_1: 1er set
-      set_2: 2ème set
-      tie_break: Tie-break
-      input_score: choisir un score
-      and_more: et plus
+      set_1: set 1
+      set_2: set 2
+      tie_break: tiebreak
+      input_score: score du set
+      and_more: et +
       save_score_btn: ⎷ Valider
       back_btn: ←
       round_not_started_flash: Le Round n'a pas commencé.

--- a/config/locales/views/matches/nl.yml
+++ b/config/locales/views/matches/nl.yml
@@ -7,9 +7,9 @@ nl:
       p01: Update of verwijder een bestaande wedstrijdscore
       match_played: "Tennisbaan:"
       date_time: "Wedstrijd gespeeld:"
-      set_1: 1e set
-      set_2: 2e setje
-      tie_break: Tie-break
+      set_1: set 1
+      set_2: set 2
+      tie_break: tiebreak
       submitted: "Score ingevoerd op %{date} door %{player}."
       update_score_btn: ⎷ Bevestigen
       delete_score_btn: x Verwijderen
@@ -23,11 +23,11 @@ nl:
       score: "Wedstrijdscore:"
       player_1: Speler 1
       player_2: Speler 2
-      set_1: 1e set
-      set_2: 2e setje
-      tie_break: Tie-break
+      set_1: set 1
+      set_2: set 2
+      tie_break: tiebreak
       input_score: kies een score
-      and_more: en meer
+      and_more: en +
       save_score_btn: ⎷ Bevestigen
       back_btn: ←
       round_not_started_flash: De ronde is nog niet begonnen.

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -10,14 +10,14 @@ en:
         The winner will receive the Singles Box League Tournament trophy, listing on the club honors board and possibly some
         champagne to celebrate at the end of the run.
       p03: The league table will be updated and displayed on the league board at the end of each round.
-      how_title: How does the Leaguebox work?
+      how_title: How does LeagueBox work?
       p04: "Each round lasts a month (or more in some clubs), and players compete within their allocated box."
       li01_html: 🎾 During the round period, play the matches in your box.
       li02_html: 💻 After each match, one of the two players <b>enters the match score</b>.
       li03_html: 🏆 The <b>league table</b> is automatically updated. You can also <b>view the boxes</b>.
       li04_html: "🎭 <b>Promotion / relegation</b>: At the end of the round, the top two players will be promoted 1 box. The last two players will be relegated 1 box."
       p05_html: Visit our <b>Tournament rules</b> page for more details
-      use_title: How to use the Leaguebox website?
+      use_title: How to use LeagueBox?
       p06: Easily follow the league table and see how you rank against other players in the box league.
       li05_html: >
         Post your latest match score in <span class='color-tennis-red'>My scores</span>.<br>
@@ -30,12 +30,12 @@ en:
         or in <span class='color-tennis-blue'>Table view</span>.
       li08_html: The <span class='color-green'>League Table</span> is always up to date, you can keep track of where every other players rank in the tournament.
       happy_tournament: Happy tournament!
-      create_club_btn: Create a new club
+      add_club_btn: Add a new club
     rules:
       overview_title: Tournament overview
       p01_html: >
         Box Leagues are designed to enable members of %{clubname} to play competitive tennis on a regular basis.
-        They are also an ideal way to meet other members and build a broader network of players for social games.
+        They are an ideal way to meet other members and build a broader network of players for social games.
       p02: >
         However, box leagues only work if players are committed to getting matches played. Members who enter the leagues must make
         every effort to complete their fixture programme. If, for whatever reason, players are unable to fulfil fixtures they
@@ -100,14 +100,13 @@ en:
       p25: >
         A player's league position is determined by the total number of points won in a Round. In the event that two or more players
         have the same number of points the league position will be determined by:
-      li13: Head to Head result (if only 2 players on the same score)
-      li14: Most matches played
-      li15: Ratio of Sets Won to Sets Played %
-      li16: Ratio of Games Won to Games Played %
+      li13: Most matches played
+      li14: Ratio of Sets Won to Sets Played %
+      li15: Ratio of Games Won to Games Played %
       promotion_relegation: Promotion / Relegation
       p26: In normal circumstances
-      li17: the top two players will be promoted 1 box.
-      li18: the last two players will be relegated 1 box.
+      li16: the top two players will be promoted 1 box.
+      li17: the last two players will be relegated 1 box.
       new_entrants: New Entrants
       p27: Every effort will be made to accommodate new league players into a box that is appropriate to the player’s ability.
       disqualification: Disqualification
@@ -115,34 +114,35 @@ en:
         Players who do not play any matches in a round without good reason or advance notice may be withdrawn from the tournament,
         at the sole discretion of the Tournament Referee.
       no_show: No Show
-      p29: If a player is more than 5 minutes late on court the opponent has the right to claim 1 game.
-      p30: If a player is more than 10 minutes late on court the opponent has the right to claim 2 games.
-      p31: If a player is more than 15 minutes late on court the opponent has the right to claim a set.
+      p29: If a player is more than
+      li18: 5 minutes late on court the opponent has the right to claim 1 game.
+      li19: 10 minutes late on court the opponent has the right to claim 2 games.
+      li20: 15 minutes late on court the opponent has the right to claim a set.
       retire_from_match: Retire from Match
-      p32: If a player retires from a match, for example because of injury, all completed games will stand. Any unplayed games will be conceded.
-      p33: "For example:"
-      p34: "Player A is leading 2/1 and 30:15 in set 1 when player A has to retire."
-      p35: The match score should be entered as 2/4 0/4 to player B.
+      p30: If a player retires from a match, for example because of injury, all completed games will stand. Any unplayed games will be conceded.
+      p31: "For example:"
+      p32: "Player A is leading 2/1 and 30:15 in set 1 when player A has to retire."
+      p33: The match score should be entered as 2/4 0/4 to player B.
       withdrawing: Withdrawing before the start of a round
-      p36: Players should inform the Tournament Referee if they wish to withdraw from the box league.
-      p37: >
+      p34: Players should inform the Tournament Referee if they wish to withdraw from the box league.
+      p35: >
         If a player withdraws before the start of a round the Tournament Referee will make every effort to maintain the player's
         position should the player rejoin the box league at the start of the next round.
       walk_overs: Walk-overs
-      p38: "Walk-overs have been abolished and are not allowed for the following reasons:"
-      li19: complications in managing walk-overs
-      li20: impossibility for the Referee to verify walk-over claims
-      li21: unfair allocation of unplayed point
+      p36: "Walk-overs have been abolished and are not allowed for the following reasons:"
+      li21: complications in managing walk-overs
+      li22: impossibility for the Referee to verify walk-over claims
+      li23: unfair allocation of unplayed point
       deadline_extensions: Deadline Extensions
-      p39: Players should make every effort to play their matches within the box league period.
-      p40: >
+      p37: Players should make every effort to play their matches within the box league period.
+      p38: >
         Players can request an extension to the deadline providing the match has been arranged and the court booked. Such requests
         will be considered at the discretion of the Tournament Referee whose decision is final.
-      p41: Players with no matches played in a round will be removed and will have to re-apply to remain in the competition.
+      p39: Players with no matches played in a round will be removed and will have to re-apply to remain in the competition.
       disputes: Disputes
       mail_to_referee_html: "your Referee %{referee_name} at %{referee_email}"
       mail_to_admin_html: "your admin at %{admin_email}"
-      p42_html: "The Tournament Referee's decision is final. All dispute inquiries to be emailed to %{mailto}."
+      p40_html: "The Tournament Referee's decision is final. All dispute inquiries to be emailed to %{mailto}."
     sitemap:
       sitemap_title: Sitemap
       home: Home

--- a/config/locales/views/pages/fr.yml
+++ b/config/locales/views/pages/fr.yml
@@ -1,23 +1,23 @@
 fr:
   pages:
     home:
-      main_title: Le tennis associatif dans votre club
-      welcome_title: Bienvenue sur le site Leaguebox
+      main_title: Le tennis associatif de votre club
+      welcome_title: Votre tournoi sur LeagueBox
       p01: >
         Le Tournoi en Simples de votre club est organisé comme une Box League proposant un round chaque mois (ou chaque trimestre dans certains clubs).
         Les points gagnés au cours de chaque round s'additionnent en un total cumulé qui déterminera le vainqueur du Tournoi.
       p02: >
         Le vainqueur recevra le trophée du Tournoi Box League, son nom sur le tableau d'honneur et pourquoi pas
         du champagne pour célébrer sa victoire à la fin du tournoi.
-      p03: La league table sera mise à jour et affichée sur le tableau à la fin des rounds.
-      how_title: Comment fonctionne la Leaguebox?
+      p03: La league table sera mise à jour automatiquement.
+      how_title: Comment fonctionne LeagueBox?
       p04: Chaque round dure un mois (ou plus selon les clubs), et les joueurs s'affrontent au sein de leur box.
       li01_html: 🎾 <b>Pendant la durée du round</b>, jouez les matchs de votre box.
       li02_html: 💻 Après chaque match, l'un des deux joueurs <b>entre le score du match</b>.
       li03_html: 🏆 La <b>league table</b> est automatiquement mise à jour. Vous pouvez également <b>consulter les box</b>.
       li04_html: "🎭 <b>Promotion / relégation</b> : À la fin du round, les deux meilleurs joueurs montent d'une box. Les deux derniers sont relégués d'une box."
       p05_html: Consultez notre page <b>Le tournoi</b> pour en savoir plus
-      use_title: Comment utilliser votre site Leaguebox?
+      use_title: Comment utilliser LeagueBox?
       p06: Suivez la league table pour vous comparer aux autres joueurs de votre box league.
       li05_html: >
         Après le match, entrez votre score dans <span class='color-tennis-red'>Mes scores</span>.<br>
@@ -30,15 +30,15 @@ fr:
         ou en <span class='color-tennis-blue'>Vue par grille</span>.
       li08_html: La <span class='color-green'>League Table</span> du round est toujours à jour, et vous pouvez vous comparer aux autres joueurs dans le tournoi.
       happy_tournament: Que les meilleurs gagnent!
-      create_club_btn: Créer un nouveau club
+      add_club_btn: Ajouter un nouveau club
     rules:
       overview_title: Description du Tournoi
       p01_html: >
         Les Box Leagues sont conçues pour permettre aux joueurs du %{clubname} de jouer régulièrement un tennis compétitif.
-        Elles sont également le moyen idéal pour rencontrer les autres membres de votre club et élargir votre réseau de tennis d'agrément.
+        Elles sont le moyen idéal pour rencontrer les autres membres de votre club et élargir votre réseau de tennis d'agrément.
       p02: >
-        Mais les Box Leagues ne marchent que si les joueurs s'engagent à jouer leurs matchs. Les membres qui s'inscrivent aux leagues
-        devront s'efforcer de programmer et jouer les matchs prévus. Si, pour quelque raison, vous ne pouvez pas jouer les matchs prévus
+        Mais les Box Leagues ne marchent que si les joueurs s'engagent à jouer leurs matchs. Les membres qui s'inscrivent
+        devront s'efforcer de programmer et jouer les matchs prévus. Si, pour quelque raison, vous ne pouvez pas jouer vos matchs
         prévenez rapidement vos adversaires et votre Referee.
       p03: >
         Les joueurs devront notifier à leurs adversaires leurs périodes d'indisponibilité, ainsi que leurs disponibilités.
@@ -97,51 +97,51 @@ fr:
       p24: Veuillez noter que tous les résultats devront être entrés avant la fin du round, à moins qu'un délai ait été accordé par le Referee.
       box_league_ranking: Classement de la Box League
       p25: >
-        Le classement d'un joueur est déterminé par le cumul des points gagnés pendant le Round. Au cas où deux joueurs ou plus
-        auraient le même nombre de points le classement sera déterminé par:
-      li13: Head to Head result (if only 2 players on the same score)
-      li14: Le plus de matchs joués
-      li15: Le Ratio de Sets Gagnés sur Sets Joués %
-      li16: Le Ratio de Jeux Gagnés sur Jeux Joués %
+        Le classement d'un joueur est déterminé par le cumul des points gagnés pendant le Round. En cas d'égalité
+        de points, le classement sera déterminé selon:
+      li13: Le plus de matchs joués
+      li14: Le Ratio de Sets Gagnés sur Sets Joués %
+      li15: Le Ratio de Jeux Gagnés sur Jeux Joués %
       promotion_relegation: Promotion / Relégation
-      p26: Dans les circonstances habituelles
-      li17: les deux meilleurs joueurs seront promus d'une 1 box.
-      li18: les deux derniers joueurs seront relégués d'une 1 box.
+      p26: Dans les circonstances habituelles, au prochain round
+      li16: les deux meilleurs joueurs seront promus d'une 1 box.
+      li17: les deux derniers joueurs seront relégués d'une 1 box.
       new_entrants: Nouveaux Entrants
-      p27: On essaiera autant que possible d'inclure les nouveaux joueurs dans une box adaptée à leur niveau.
+      p27: Le Referee essaiera autant que possible d'inclure les nouveaux joueurs dans une box adaptée à leur niveau.
       disqualification: Disqualification
       p28: >
         Les joueurs qui n'auront pas joué de match dans leur round sans raison valable ou avoir prévenu peuvent être disqualifiés du tournoi,
         à la seule discrétion du Referee du Tournoi.
       no_show: No Show
-      p29: Si un joueur a plus de 5 minutes de retard sur le court son adversaire peut exiger 1 jeu.
-      p30: Si un joueur a plus de 10 minutes de retard sur le court son adversaire peut exiger 2 jeux.
-      p31: Si un joueur a plus de 15 minutes de retard sur le court son adversaire peut exiger a set.
+      p29: Si un joueur a plus de
+      li18: 5 minutes de retard sur le court son adversaire peut exiger 1 jeu.
+      li19: 10 minutes de retard sur le court son adversaire peut exiger 2 jeux.
+      li20: 15 minutes de retard sur le court son adversaire peut exiger a set.
       retire_from_match: Forfait d'un Match
-      p32: Si un joueur déclare forfait, pour blessure par exemple, tous les jeux joués compteront. Les jeux non joués seront déclarés perdus.
-      p33: "Par exemple:"
-      p34: "Le Joueur A mène 2/1, 30:15 au premier set et doit déclarer forfait."
-      p35: Le score du match à saisir sera 2/4 0/4 à l'avantage du Joueur B.
+      p30: Si un joueur déclare forfait, pour blessure par exemple, tous les jeux joués compteront. Les jeux non joués seront déclarés perdus.
+      p31: "Par exemple:"
+      p32: "Le Joueur A mène 2/1, 30:15 au premier set et doit déclarer forfait."
+      p33: Le score du match à saisir sera 2/4 0/4 à l'avantage du Joueur B.
       withdrawing: Retrait avant le début d'un round
-      p36: Les joueurs informeront le Referee s'ils souhaitent se retirer de la box league.
-      p37: >
+      p34: Les joueurs informeront le Referee s'ils souhaitent se retirer de la box league.
+      p35: >
         Si le joueur se retire avant le début du round, le Referee s'efforcera pour maintenir sa position dans la league
         s'il souhaitait participer au round suivant.
       walk_overs: Victoire par forfait ou absence (Walk-over)
-      p38: "Les walk-overs ont été abolis et ne sont plus autorisés pour les raisons suivantes:"
-      li19: compliqués à gérer
-      li20: il est impossible pour le Referee de vérifier les déclarations de walk-overs
-      li21: attribution injuste de points non joués
+      p36: "Les walk-overs ont été abolis et ne sont plus autorisés pour les raisons suivantes:"
+      li21: compliqués à gérer
+      li22: il est impossible pour le Referee de vérifier les déclarations de walk-overs
+      li23: attribution injuste de points non joués
       deadline_extensions: Deadline Extensions
-      p39: les joueurs devront s'efforcer de jouer leurs matchs dans la durée de la box league.
-      p40: >
+      p37: Les joueurs devront s'efforcer de jouer leurs matchs dans la durée de la box league.
+      p38: >
         Les joueurs pourront demander un délai à condition que le match ait été arrangé et le court réservé. Une telle requête
         sera jugée à la discrétion du Referee du Tournoi dont la décision sera définitive.
-      p41: Les joueurs n'ayant pas joué leurs matchs pendant un round seront retirés et devront se réinscrire pour rester dans le Tournoi.
+      p39: Les joueurs n'ayant pas joué leurs matchs pendant un round seront retirés et devront se réinscrire pour rester dans le Tournoi.
       disputes: Différends
       mail_to_referee_html: "votre Referee %{referee_name} à %{referee_email}"
       mail_to_admin_html: "votre admin à %{admin_email}"
-      p42_html: "les décisions du Referee du Tournoi sont définitives. Toute demande de différend est à adresser à %{mailto}."
+      p40_html: "Les décisions du Referee du Tournoi sont définitives. Toute demande de différend est à adresser à %{mailto}."
     sitemap:
       sitemap_title: Plan du site
       home: Page d'accueil

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -2,7 +2,7 @@ nl:
   pages:
     home:
       main_title: Verenigingstennis in jouw club
-      welcome_title: Welkom op de Leaguebox-website
+      welcome_title: Welkom op de LeagueBox-website
       p01: >
         Het Singles Tournament wordt georganiseerd als een Box League en biedt elke maand een ronde (of elke drie maanden, in sommige club).
         De tijdens elke ronde verdiende punten vormen een cumulatief totaal dat de winnaar van het toernooi bepaalt.
@@ -10,14 +10,14 @@ nl:
         De winnaar ontvangt de Singles Box League Tournament-trofee, zijn of haar naam op de erelijst en waarom niet
         champagne om zijn overwinning aan het einde van de ronde te vieren.
       p03: De ranglijst wordt aan het einde van de rondes bijgewerkt en op het bord weergegeven.
-      how_title: Hoe werkt Leaguebox?
+      how_title: Hoe werkt LeagueBox?
       p04: Elke ronde duurt een maand (of meer in sommige clubs) en spelers strijden in hun box.
       li01_html: 🎾 <b>Gedurende de ronde</b> speel de wedstrijden in je box.
       li02_html: 💻 Na elke wedstrijd <b>voert een van de twee spelers de wedstrijdscore in</b>.
       li03_html: 🏆 De <b>ranglijst</b> wordt automatisch bijgewerkt. U kunt ook <b>de boxen bekijken</b>.
       li04_html: "🎭 <b>Promotie / degradatie</b>: Aan het einde van de ronde gaan de twee beste spelers één vak omhoog. De laatste twee degraderen één vakje."
       p05_html: Bezoek onze pagina <b>Toernooiregels</b> voor meer informatie
-      use_title: Gebruik van de Leaguebox-website
+      use_title: Gebruik van de LeagueBox-website
       p06: Volg de ranglijst om jezelf te vergelijken met andere spelers in je competitievak
       li05_html: >
         Voer je laatste score in <span class='color-tennis-red'>Mijn scores</span>.<br>
@@ -30,7 +30,7 @@ nl:
         of in <span class='color-tennis-blue'>Resultatenraster</span>.
       li08_html: De <span class='color-green'>League Table</span> wordt altijd bijgewerkt en je kunt de ranglijst van alle andere spelers in het toernooi volgen.
       happy_tournament: Happy tournament!
-      create_club_btn: Creëer een nieuwe club
+      add_club_btn: Een nieuwe club toevoegen
     rules:
       overview_title: Beschrijving van het toernooi
       p01_html: >
@@ -99,14 +99,13 @@ nl:
       p25: >
         De rangschikking van een speler wordt bepaald door de cumulatieve punten die tijdens de ronde zijn verdiend. In geval van twee of meer spelers
         hetzelfde aantal punten zou hebben, wordt de rangschikking bepaald door:
-      li13: Head to Head-resultaat (als slechts 2 spelers dezelfde score hebben)
-      li14: Meeste wedstrijden gespeeld
-      li15: De verhouding tussen gewonnen sets en gespeelde sets %
-      li16: De verhouding tussen gewonnen games en gespeelde games %
+      li13: Meeste wedstrijden gespeeld
+      li14: De verhouding tussen gewonnen sets en gespeelde sets %
+      li15: De verhouding tussen gewonnen games en gespeelde games %
       promotion_relegation: Promotie/degradatie
       p26: Onder normale omstandigheden
-      li17: de twee beste spelers promoveren met 1 box.
-      li18: de laatste twee spelers degraderen één box.
+      li16: de twee beste spelers promoveren met 1 box.
+      li17: de laatste twee spelers degraderen één box.
       new_entrants: Nieuwkomers
       p27: We zullen zoveel mogelijk proberen nieuwe spelers op te nemen in een box die is aangepast aan hun niveau.
       disqualification: Diskwalificatie
@@ -114,34 +113,35 @@ nl:
         Spelers die zonder geldige reden of na kennisgeving geen wedstrijd in hun ronde spelen, kunnen worden gediskwalificeerd voor het toernooi,
         naar eigen goeddunken van de toernooiReferee.
       no_show: No Show
-      p29: Als een speler meer dan 5 minuten te laat op het speelveld is, mag zijn tegenstander 1 game eisen.
-      p30: Als een speler meer dan 10 minuten te laat op het speelveld is, mag zijn tegenstander 2 games eisen.
-      p31: Als een speler meer dan 15 minuten te laat op het speelveld is, mag zijn tegenstander een set eisen.
+      p29: Als een speler meer dan
+      li18: 5 minuten te laat op het speelveld is, mag zijn tegenstander 1 game eisen.
+      li19: 10 minuten te laat op het speelveld is, mag zijn tegenstander 2 games eisen.
+      li20: 15 minuten te laat op het speelveld is, mag zijn tegenstander een set eisen.
       retire_from_match: Terugtrekt van een Match
-      p32: Als een speler zich terugtrekt, bijvoorbeeld vanwege een blessure, tellen alle gespeelde wedstrijden mee. Niet gespeelde wedstrijden worden verloren verklaard.
-      p33: "Bijvoorbeeld:"
-      p34: "Speler A leidt 2/1, 30:15 in de eerste set en moet opgeven."
-      p35: De score van de in te voeren wedstrijd is 2/4 0/4 in het voordeel van speler B.
+      p30: Als een speler zich terugtrekt, bijvoorbeeld vanwege een blessure, tellen alle gespeelde wedstrijden mee. Niet gespeelde wedstrijden worden verloren verklaard.
+      p31: "Bijvoorbeeld:"
+      p32: "Speler A leidt 2/1, 30:15 in de eerste set en moet opgeven."
+      p33: De score van de in te voeren wedstrijd is 2/4 0/4 in het voordeel van speler B.
       withdrawing: Terugtrekking vóór aanvang van een ronde
-      p36: Spelers informeren de Referee als ze zich willen terugtrekken uit de Box League.
-      p37: >
+      p34: Spelers informeren de Referee als ze zich willen terugtrekken uit de Box League.
+      p35: >
         Als de speler zich vóór het begin van de ronde terugtrekt, zal de Referee proberen zijn positie in de competitie te behouden
         als hij wilde deelnemen aan de volgende ronde.
       walk_overs: Overwinning door verbeurdverklaring of afwezigheid (walk-over)
-      p38: "Walk-overs zijn afgeschaft en niet meer toegestaan ​​om de volgende redenen:"
-      li19: ingewikkeld om te beheren
-      li20: het is voor de Referee onmogelijk om walk-over-verklaringen te verifiëren
-      li21: oneerlijke toewijzing van niet-gespeelde punten
+      p36: "Walk-overs zijn afgeschaft en niet meer toegestaan ​​om de volgende redenen:"
+      li21: ingewikkeld om te beheren
+      li22: het is voor de Referee onmogelijk om walk-over-verklaringen te verifiëren
+      li23: oneerlijke toewijzing van niet-gespeelde punten
       deadline_extensions: Deadline-verlengingen
-      p39: Spelers zullen ernaar moeten streven hun wedstrijden binnen de duur van de Box League te spelen.
-      p40: >
+      p37: Spelers zullen ernaar moeten streven hun wedstrijden binnen de duur van de Box League te spelen.
+      p38: >
         Spelers kunnen om uitstel verzoeken, op voorwaarde dat de wedstrijd is geregeld en de baan is gereserveerd. Zo'n verzoek
         zal worden beoordeeld naar goeddunken van de toernooiReferee, wiens beslissing definitief zal zijn.
-      p41: Spelers die hun wedstrijden tijdens een ronde niet hebben gespeeld, worden teruggetrokken en moeten zich opnieuw registreren om in het toernooi te blijven.
+      p39: Spelers die hun wedstrijden tijdens een ronde niet hebben gespeeld, worden teruggetrokken en moeten zich opnieuw registreren om in het toernooi te blijven.
       disputes: Geschillen
       mail_to_referee_html: "uw Referee %{referee_name} aan %{referee_email}"
       mail_to_admin_html: "uw admin aan %{admin_email}"
-      p42_html: "De beslissingen van de Referee zijn definitief. Elk geschilverzoek moet worden verzonden naar %{mailto}."
+      p40_html: "De beslissingen van de Referee zijn definitief. Elk geschilverzoek moet worden verzonden naar %{mailto}."
     sitemap:
       sitemap_title: Sitemap
       home: Home

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -16,7 +16,7 @@ en:
       general_chat_link: "#general chatroom"
       chatrooms_link: Chatrooms
       log_out_link: Log out
-    round:
+    display_round:
       round_period: "Round %{start} to %{end}"
     select_round:
       select_round_start: "Select a different round: "
@@ -34,11 +34,11 @@ en:
         &emsp;&emsp;&emsp;→ contact your Referee through the <b>chatroom</b>.
       staff_p03_html: >
         <b>You cannot enter the match score</b>?<br>
-        &emsp;&emsp;&emsp;→ contact your Referee, or the admin through <b>Contact Us</b>.
+        &emsp;&emsp;&emsp;→ contact your Referee, or the admin through the <b>Contact Us</b> link.
+      header_role: 🧩 Role
       header_name: Name
       header_club: 🎾 Club
       header_email: ✉️ email
       header_phone: 📞 Telephone
-      header_role: 🧩 Role
       website_admin: Website admin
       club_referee_html: "%{club_name} Referee"

--- a/config/locales/views/shared/fr.yml
+++ b/config/locales/views/shared/fr.yml
@@ -16,7 +16,7 @@ fr:
       general_chat_link: "Chatroom #general"
       chatrooms_link: Les chatrooms
       log_out_link: Déconnexion
-    round:
+    display_round:
       round_period: "Round %{start} au %{end}"
     select_round:
       select_round_start: "Consulter un autre round: "
@@ -34,11 +34,11 @@ fr:
         &emsp;&emsp;&emsp;→ contactez votre Referee via la <b>chatroom</b>.
       staff_p03_html: >
         <b>Vous ne pouvez entrer votre score</b>?<br>
-        &emsp;&emsp;&emsp;→ contactez votre Referee, ou l'admin via <b>Nous Contacter</b>.
+        &emsp;&emsp;&emsp;→ contactez votre Referee, ou l'admin via le lien <b>Nous Contacter</b>.
+      header_role: 🧩 Fonction
       header_name: Nom
       header_club: 🎾 Club
       header_email: ✉️ email
       header_phone: 📞 Téléphone
-      header_role: 🧩 Rôle
       website_admin: Administrateur du site
       club_referee_html: "Referee du %{club_name}"

--- a/config/locales/views/shared/nl.yml
+++ b/config/locales/views/shared/nl.yml
@@ -16,7 +16,7 @@ nl:
       general_chat_link: "Chatroom #general"
       chatrooms_link: Chatrooms
       log_out_link: Uitloggen
-    round:
+    display_round:
       round_period: "Ronde %{start} tot %{end}"
     select_round:
       select_round_start: "Bekijk een andere ronde: "
@@ -34,11 +34,11 @@ nl:
         &emsp;&emsp;&emsp;→ Neem contact op met uw scheidsrechter via jouw <b>box chatroom</b>.
       staff_p03_html: >
         <b>U kunt de wedstrijdscore niet invoeren</b>?<br>
-        &emsp;&emsp;&emsp;→ Neem contact op met uw scheidsrechter, of de beheerder via <b>Contact</b>.
+        &emsp;&emsp;&emsp;→ Neem contact op met uw scheidsrechter, of de beheerder via de link <b>Contact</b>.
+      header_role: 🧩 Rol
       header_name: Naam
       header_club: 🎾 Club
       header_email: ✉️ E-mail
       header_phone: 📞 Telefoon
-      header_role: 🧩 Rol
       website_admin: Sitebeheerder (admin)
       club_referee_html: "Referee van %{club_name}"

--- a/config/locales/views/user_box_scores/en.yml
+++ b/config/locales/views/user_box_scores/en.yml
@@ -13,7 +13,6 @@ en:
         In the event that two or more players have the same number of points the league position will be
         determined by:<br /><br />
         <ol>
-          <li>Head to Head result (if only 2 players on the same score)</li>
           <li>Most matches played</li>
           <li>Ratio of sets won to sets played</li>
           <li>Ratio of games won to games played</li>
@@ -21,14 +20,6 @@ en:
     buttons:
       to_text_btn: Export page to text file
       to_csv_btn: Export page to CSV file
-      # player_header: Player
-      # rank_header: Rank
-      # points_header: Points
-      # box_header: Box
-      # matches_played_header: Matches Played
-      # matches_won_header: Matches Won
-      # sets_played_header: Sets Played
-      # sets_won_header: Sets Won
     table_data:
       matches:
         zero: 0 matches
@@ -42,11 +33,11 @@ en:
       player_header: Player
       rank_header: Rank
       points_header: Points
-      box_header: Box
-      matches_played_header: Matches Played
-      matches_won_header: Matches Won
-      sets_played_header: Sets Played
-      sets_won_header: Sets Won
+      box_header: Box nb
+      matches_played_header: Played
+      matches_won_header: Won
+      sets_played_header: Played
+      sets_won_header: Won
     new:
       new_club_title: Create a new club and a round
       not_authorised: You are not an admin, this page is not authorised.

--- a/config/locales/views/user_box_scores/fr.yml
+++ b/config/locales/views/user_box_scores/fr.yml
@@ -12,7 +12,6 @@ fr:
         Le classement d'un joueur dans la league table est déterminé par le cumul de points gagnés pendant le round.<br />
         Si deux joueurs cumulent le même nombre de points, le classement sera déterminé selon les critères suivants:<br /><br />
         <ol>
-          <li>Head to Head result (if only 2 players on the same score)</li>
           <li>Le plus de matchs joués</li>
           <li>Ratio sets gagnés sur sets joués</li>
           <li>Ratio jeux gagnés sur jeux joués</li>
@@ -20,14 +19,6 @@ fr:
     buttons:
       to_text_btn: Exporter vers un fichier texte
       to_csv_btn: Exporter vers un fichier CSV
-      # player_header: Joueurs
-      # rank_header: Rang
-      # points_header: Points
-      # box_header: Box
-      # matches_played_header: Matchs Joués
-      # matches_won_header: Matchs Gagnés
-      # sets_played_header: Sets Joués
-      # sets_won_header: Sets Gagnés
     table_data:
       matches:
         zero: 0 match
@@ -41,11 +32,11 @@ fr:
       player_header: Joueur
       rank_header: Rang
       points_header: Points
-      box_header: Box
-      matches_played_header: Matchs Joués
-      matches_won_header: Matchs Gagnés
-      sets_played_header: Sets Joués
-      sets_won_header: Sets Gagnés
+      box_header: Box nº
+      matches_played_header: Joués
+      matches_won_header: Gagnés
+      sets_played_header: Joués
+      sets_won_header: Gagnés
     new:
       new_club_title: Générer un nouveau club et un round
       not_authorised: Vous n'êtes pas admin, cette page n'est pas authorisée.

--- a/config/locales/views/user_box_scores/nl.yml
+++ b/config/locales/views/user_box_scores/nl.yml
@@ -12,7 +12,6 @@ nl:
         De rangschikking van een speler in de ranglijst wordt bepaald door het totaal aantal punten dat tijdens de ronde is verdiend.<br />
         Als twee spelers hetzelfde aantal punten verzamelen, wordt de rangschikking bepaald op basis van de volgende criteria:<br /><br />
         <ol>
-          <li>Head to Head result (if only 2 players on the same score)</li>
           <li>Meeste wedstrijden gespeeld</li>
           <li>Verhouding tussen gewonnen sets en gespeelde sets</li>
           <li>Verhouding tussen gewonnen games en gespeelde games</li>
@@ -20,14 +19,6 @@ nl:
     buttons:
       to_text_btn: Exporteren naar tekstbestand
       to_csv_btn: Exporteren naar CSV-bestand
-      # player_header: Spelers
-      # rank_header: Rang
-      # points_header: Punten
-      # box_header: Box
-      # matches_played_header: Wedstrijden gespeeld
-      # matches_won_header: Gewonnen wedstrijden
-      # sets_played_header: Gespeelde sets
-      # sets_won_header: Sets gewonnen
     table_data:
       matches:
         zero: 0 wedstrijden
@@ -42,10 +33,10 @@ nl:
       rank_header: Rang
       points_header: Punten
       box_header: Box
-      matches_played_header: Wedstrijden gespeeld
-      matches_won_header: Gewonnen wedstrijden
-      sets_played_header: Gespeelde sets
-      sets_won_header: Sets gewonnen
+      matches_played_header: Gespeeld
+      matches_won_header: Gewonnen
+      sets_played_header: Gespeeld
+      sets_won_header: Gewonnen
     new:
       new_club_title: Genereer een nieuwe club en ronde
       not_authorised: U bent geen beheerder, deze pagina is niet geautoriseerd.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     resources :matches, only: %i[show edit update new create destroy]
 
     resources :user_box_scores, only: %i[index new create]
-    get 'user_box_scores/download_csv', to: "user_box_scores#download_csv", as: "download"
+    get 'user_box_scores/league_table_to_csv', to: "user_box_scores#league_table_to_csv", as: "csv"
 
     resources :rounds, only: %i[new create]
 

--- a/public/404.html
+++ b/public/404.html
@@ -77,7 +77,7 @@
   <!-- This file lives in public/404.html -->
   <div class="image-front"
     style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('/social_tennis.jpg')">
-    <br><h4 class="mx-5 image-front-text">League Box</h4><br>
+    <br><h4 class="mx-5 image-front-text">LeagueBox</h4><br>
   </div><br>
 
   <div class="container">

--- a/public/500.html
+++ b/public/500.html
@@ -77,7 +77,7 @@
   <!-- This file lives in public/500.html -->
   <div class="image-front"
     style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('/social_tennis.jpg')">
-    <br><h4 class="mx-5 image-front-text">League Box</h4><br>
+    <br><h4 class="mx-5 image-front-text">LeagueBox</h4><br>
   </div><br>
 
   <div class="container">
@@ -86,7 +86,7 @@
         <img src="/tennis_racket.jpg" alt="tennis_racket image"  height=50>
       </div>
       <div class="frame-color-shape">
-        <!-- <h1>League box</h1> -->
+        <!-- <h1>LeagueBox</h1> -->
         <h3>We're sorry, but something went wrong.</h3>
         <p></p>
         <p>Please contact the application admin.</p>

--- a/public/data.csv
+++ b/public/data.csv
@@ -1,4 +1,4 @@
-mercredi 27 décembre 2023 19:29,Joueur,Rang,Points,Box,Matchs Joués,Matchs Gagnés,Sets Joués,Sets Gagnés
+27 déc. 22:38,Joueur,Rang,Points,Box,Matchs Joués,Matchs Gagnés,Sets Joués,Sets Gagnés
 1,Kristopher Cronin,1,44,2,3,2,7,4
 2,Dick Cartwright,2,40,1,2,2,4,4
 3,Graig Cruickshank,3,20,2,1,1,2,2


### PR DESCRIPTION
- button color formatting, renamed btn-blue to btn-yellow
- box-width changed 80rem to 85vw- reduced grid container padding to 20px
- chatrooms renamed: the rounds are numbers for each year and the round number appears as B[nn]/R[yy_nn] instead of the round id: B[nn]/R[id]
- in user_box_scores/index view (league table) reduced the nb of buttons and the 'Export to CSV' now triggers the download.
- added some © symbols next to League Box
- improved display and responsiveness of matches/new and matches/edit views
- improved ux for matches/new: only 3 dropdown lists instead of 6 for inputting a new score
- dropped the time of match (without changing the model)
- modified some text and yml variable numbers in pages/rules
- the image text overlay now only displays the club name if user is not admin
- changed headers names in boxes/show_list
