### PR TITLE
added round creation from CSV file

### DIFF
--- a/app/controllers/user_box_scores_controller.rb
+++ b/app/controllers/user_box_scores_controller.rb
@@ -150,7 +150,7 @@ class UserBoxScoresController < ApplicationController
         box_players = []
         boxes = []
         nb_boxes.times do |box_index|
-          # TO DO: create a now chatroom for the box
+          # TO DO: create a new chatroom for the box
           boxes << Box.create(round_id: round.id, box_number: box_index + 1, chatroom_id: @general_chatroom.id)
           box_players << players.shift(players_per_box)
           box_players[box_index].each do |player|
@@ -161,7 +161,7 @@ class UserBoxScoresController < ApplicationController
                                 games_won: 0, games_played: 0)
           end
         end
-        flash[:notice] += t('.club_created', count: players.count % players_per_box, players: players_per_box)
+        flash[:notice] = t('.club_created', count: players.count % players_per_box, players: players_per_box)
         if (players.count % players_per_box).positive?
           players.each(&:destroy) # destroy all remaining players (when less than MIN_PLAYERS_PER_BOX are left)
         end

--- a/app/views/boxes/index.html.erb
+++ b/app/views/boxes/index.html.erb
@@ -42,11 +42,11 @@
         <%= link_to t('.to_csv_btn'), csv_boxes_path(round_id: @round.id), class: "btn buttons-shape btn-green dont-print text-size" %>
         &nbsp;&nbsp;&nbsp;&nbsp;
       <% end %>
-      <% if current_user && current_user.role == "admin" %>
+      <% if current_user && current_user.role == "admin" && @new_round_required %>
           <!-- allow referee/admin to create next round up to 15 days before or 300 days after end of last round
           TO DO: add a time related condition here for the button to appear -->
           <%= link_to t(".create_round_btn"), new_round_path(club_id: @round.club_id), class: "btn buttons-shape btn-aqua" %>
-      <% elsif current_user && current_user.role == "referee" %>
+      <% elsif current_user && current_user.role == "referee" && @new_round_request%>
           <%= link_to t(".request_round_btn"), new_contact_path(round_id: @round.id), class: "btn buttons-shape btn-aqua" %>
       <% end %>
     </div>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -110,7 +110,7 @@
         required: true
       %>
 
-      <!--- form field SECURITY CHECK (hidden) -->
+      <%# form field SECURITY CHECK (hidden) %>
       <%= f.text_field :formcheck,
         type:"hidden"
       %>

--- a/app/views/rounds/new.html.erb
+++ b/app/views/rounds/new.html.erb
@@ -4,6 +4,7 @@
       data-bs-trigger="hover" data-bs-placement="right" data-bs-delay= '{ "show": 500 }'
       title="Box moves" data-bs-content="<%= t '.message' %>">
     <h3><%= t '.new_round_title' %></h3>
+    <h4><%= t '.new_round_subtitle' %></h4>
   </div>
   <% if @new_round %>
     <h4><%= @current_round.club.name %></h4>
@@ -36,7 +37,12 @@
           <!--  end of the form: input start_date, end_date and submit -->
           <div class="new_round-box small-font">
             <div class="box-title"><b><%= t '.new_round' %></b></div>
-            <br><br><%= t '.start_date' %>
+            <br><div>
+              <%# file_field_tag :csv_file, accept: 'text/csv' %>
+              <%= f.file_field :csv_file, accept: 'text/csv' %>
+              <br class="small-font"><i><%= t '.warning' %></i>
+            </div>
+            <%= t '.start_date' %>
             <%#  proposed start_date : current end_date + 1 day, min value : current end_date + 1 day %>
             <%= f.date_field(:start_date, min: @current_round.end_date + 1, value: @current_round.end_date + 1 ) %>
             <%#  current round's duration in months %>
@@ -45,10 +51,10 @@
             <%#  proposed end_date : current end_date + duration in months, min value : current end_date + 1 month %>
             <%= f.date_field(:end_date, min: @current_round.end_date >> 1, value: @current_round.end_date >> duration ) %>
             <%= hidden_field_tag(:club_id, @current_round.club_id) %>
-            <div class="buttons-wrap">
-              <div class="box-title"><%= f.submit t(".create_round_btn"), class: "btn buttons-shape btn-green" %></div>
+            <div class="one-liner">
+              <%= f.submit t(".create_round_btn"), class: "btn buttons-shape btn-green" %>
               &nbsp;&nbsp;&nbsp;&nbsp;
-              <%= link_to "Back", :back, class: "btn buttons-shape btn-yellow" %>
+              <%= link_to "Back", boxes_path(round_id: @current_round.id, club_id: @current_round.club_id), class: "btn buttons-shape btn-yellow" %>
             </div>
           </div>
         </div>

--- a/app/views/shared/_display_round.html.erb
+++ b/app/views/shared/_display_round.html.erb
@@ -5,6 +5,6 @@
     end: l(round.end_date, format: @is_mobile ? :ddmmm_date : :ddmmmyy_date),
     round: @round_nb) %>
 <% if round.end_date > Date.today %>
-  <%= t(".days_left", days: (round.end_date - Date.today).to_i) %>
+  <span class="color-tennis-red"><%= t(".days_left", days: (round.end_date - Date.today).to_i) %></span>
 <% end %>
 <%= t(".players", nb_players: round.boxes.map {|box| box.user_box_scores.count}.sum) %>&nbsp;

--- a/config/locales/views/rounds/en.yml
+++ b/config/locales/views/rounds/en.yml
@@ -1,7 +1,8 @@
 en:
   rounds:
     new:
-      new_round_title: Proposed player moves for next round
+      new_round_title: Next round creation
+      new_round_subtitle: Upload a CSV file or enter player moves
       message: >
           Select box move, for example:<br />
           2 = two boxes up,<br />
@@ -12,5 +13,12 @@ en:
       message_boxes: player name, rank,<br />nb matches played, proposed box move
       start_date: "Start date :"
       end_date: "End date :"
-      create_round_btn: ⎷ Create new round
+      warning: If a file is uploaded, player moves won't operate
+      create_round_btn: ⎷ Create round
       new_round: New round
+    create:
+      header_flash: Your headers must include "id", "email", "first_name", "last_name", "nickname"[optional], "phone_number", and "role".
+      round_created:
+        zero: Round created with %{players} players per box. All players were included.
+        one: Round created with %{players} players per box. Last player could not be accomodated.
+        other: Round created with %{players} players per box. Last %{count} players could not be accommodated.

--- a/config/locales/views/rounds/fr.yml
+++ b/config/locales/views/rounds/fr.yml
@@ -1,7 +1,8 @@
 fr:
   rounds:
     new:
-      new_round_title: "Prochain round: mouvement des joueurs"
+      new_round_title: Création du prochain round
+      new_round_subtitle: Charger un fichier CSV ou choisir le mouvement des joueurs
       message: >
           Choisir une promotion, par exemple:<br />
           2 = promotion deux box,<br />
@@ -12,5 +13,12 @@ fr:
       message_boxes: joueur, classement,<br />nb matchs joués, mouvement proposé
       start_date: "Date de départ:"
       end_date: "Date de fin:"
-      create_round_btn: ⎷ Créer le round
+      warning: Si un fichier est chargé, les movements ne seront pas considérés
+      create_round_btn: ⎷ Créer round
       new_round: Nouveau round
+    create:
+      header_flash: Les entêtes doivent inclure "id", "email", "first_name", "last_name", "nickname"[optionnel], "phone_number", et "role".
+      round_created:
+        zero: Round créé avec %{players} joueurs par box. Tous les joueurs ont été inclus.
+        one: Round créé avec %{players} joueurs par box. Le dernier joueur n'a pu être inclus.
+        other: Round créé avec %{players} joueurs par box. Les %{count} derniers joueurs n'ont pu être inclus.

--- a/config/locales/views/rounds/nl.yml
+++ b/config/locales/views/rounds/nl.yml
@@ -1,7 +1,8 @@
 nl:
   rounds:
     new:
-      new_round_title: "Volgende ronde: spelersbeweging"
+      new_round_title: Volgende ronde creatie
+      new_round_subtitle: Upload een CSV-bestand of voer spelerbewegingen in
       message: >
           Kies een promotie, bijvoorbeeld:<br />
           2 = promotie twee boxen,<br />
@@ -12,5 +13,12 @@ nl:
       message_boxes: speler, rangschikking,<br />aantal gespeelde wedstrijden, voorgestelde zet
       start_date: "Begin datum:"
       end_date: "Einddatum:"
+      warning: Als een bestand wordt geüpload, worden de spelerbewegingen niet gebruikt
       create_round_btn: ⎷ Maak de ronde
       new_round: Volgende ronde
+    create:
+      header_flash: De headers moeten 'id', 'e-mail', 'voornaam', 'achternaam', 'bijnaam' [optioneel], 'telefoonnummer' en 'rol' bevatten.
+      round_created:
+        zero: Round gemaakt met %{players} spelers per box. Alle spelers waren aanwezig.
+        one: Round gemaakt met %{players} spelers per box. De laatste speler konde niet worden ondergebracht.
+        other: Round gemaakt met %{players} spelers per box. De laatste %{count} spelers konden niet worden ondergebracht.

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -19,7 +19,7 @@ en:
     display_round:
       round_period: Round %{round} (%{start} to %{end})
       round_period_mobile: R%{round}
-      days_left: (%{days} days left)
+      days_left: "%{days} days left"
       players: ", %{nb_players} players"
     select_round:
       select_round_start: "Select a different round: "

--- a/config/locales/views/shared/fr.yml
+++ b/config/locales/views/shared/fr.yml
@@ -19,7 +19,7 @@ fr:
     display_round:
       round_period: Round %{round} (%{start} au %{end})
       round_period_mobile: R%{round}
-      days_left: (%{days} jours restants)
+      days_left: "%{days} jours restants"
       players: "%{nb_players} joueurs"
     select_round:
       select_round_start: "Consulter un autre round: "

--- a/config/locales/views/shared/nl.yml
+++ b/config/locales/views/shared/nl.yml
@@ -19,7 +19,7 @@ nl:
     display_round:
       round_period: Ronde %{round} (%{start} tot %{end})
       round_period_mobile: R%{round}
-      days_left: (%{days} dagen over)
+      days_left: "%{days} dagen over"
       players: "%{nb_players} spellers"
     select_round:
       select_round_start: "Bekijk een andere ronde: "

--- a/config/locales/views/user_box_scores/en.yml
+++ b/config/locales/views/user_box_scores/en.yml
@@ -76,7 +76,7 @@ en:
     create:
       header_flash: Your headers must be "id", "email", "first_name", "last_name", "nickname"[optional], "phone_number", and "role".
       file_type_flash: Please chose a csv file type.
-    club_created:
-      zero: Club created with %{players} players per box. All players were included.
-      one: Club created with %{players} players per box. Last player could not be accomodated.
-      other: Club created with %{players} players per box. Last %{count} players could not be accommodated.
+      club_created:
+        zero: Club created with %{players} players per box. All players were included.
+        one: Club created with %{players} players per box. Last player could not be accomodated.
+        other: Club created with %{players} players per box. Last %{count} players could not be accommodated.

--- a/config/locales/views/user_box_scores/fr.yml
+++ b/config/locales/views/user_box_scores/fr.yml
@@ -75,7 +75,7 @@ fr:
     create:
       header_flash: Les entêtes doivent être "id", "email", "first_name", "last_name", "nickname"[optionnel], "phone_number", et "role".
       file_type_flash: Choisissez un fichier de type csv.
-    club_created:
-      zero: Club créé avec %{players} joueurs par box. Tous les joueurs ont été inclus.
-      one: Club créé avec %{players} joueurs par box. Le dernier joueur n'a pu être inclus.
-      other: Club créé avec %{players} joueurs par box. Les %{count} derniers joueurs n'ont pu être inclus.
+      club_created:
+        zero: Club créé avec %{players} joueurs par box. Tous les joueurs ont été inclus.
+        one: Club créé avec %{players} joueurs par box. Le dernier joueur n'a pu être inclus.
+        other: Club créé avec %{players} joueurs par box. Les %{count} derniers joueurs n'ont pu être inclus.

--- a/config/locales/views/user_box_scores/nl.yml
+++ b/config/locales/views/user_box_scores/nl.yml
@@ -75,7 +75,7 @@ nl:
     create:
       header_flash: De headers moeten 'id', 'e-mail', 'voornaam', 'achternaam', 'bijnaam' [optioneel], 'telefoonnummer' en 'rol' zijn.
       file_type_flash: Kies een csv-bestandstype.
-    club_created:
-      zero: Club gemaakt met %{players} spelers per box. Alle spelers waren aanwezig.
-      one: Club gemaakt met %{players} spelers per box. De laatste speler konde niet worden ondergebracht.
-      other: Club gemaakt met %{players} spelers per box. De laatste %{count} spelers konden niet worden ondergebracht.
+      club_created:
+        zero: Club gemaakt met %{players} spelers per box. Alle spelers waren aanwezig.
+        one: Club gemaakt met %{players} spelers per box. De laatste speler konde niet worden ondergebracht.
+        other: Club gemaakt met %{players} spelers per box. De laatste %{count} spelers konden niet worden ondergebracht.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     get "sitemap", to: "pages#sitemap", as: "sitemap"
 
     resources :boxes, only: %i[index show]
-    get 'boxes_csv/boxes', to: "boxes#league_boxes_to_csv", as: "csv_boxes"
+    get 'boxes_csv/boxes', to: "boxes#league_round_to_csv", as: "csv_boxes"
     get "boxes_list/:id", to: "boxes#show_list", as: "box_list"
     get "my_scores/:id", to: "boxes#my_scores", as: "my_scores"
 

--- a/public/data.csv
+++ b/public/data.csv
@@ -1,85 +1,67 @@
-01 fév. 18:03,id,email,first_name,last_name,nickname,phone_number,role,box,club
-1,174,frederic.brakus@club.be,Frederic,Brakus,FredericB,843-851-5544,player,1,Wimbledon Ltc Club
-2,175,brent.emard@club.be,Brent,Emard,BrentE,602.155.5616,player,1,Wimbledon Ltc Club
-3,177,aurelio.boyle@club.be,Aurelio,Boyle,AurelioB,(565) 886-7164,player,1,Wimbledon Ltc Club
-4,178,stanton.schmidt@club.be,Stanton,Schmidt,StantonS,175-672-6053,player,1,Wimbledon Ltc Club
-5,179,frederick.nicolas@club.be,Frederick,Nicolas,FrederickN,(839) 348-5521,player,1,Wimbledon Ltc Club
-6,176,chuck.cartwright@club.be,Chuck,Cartwright,ChuckC,1-870-464-0847,player,1,Wimbledon Ltc Club
-7,201,abe.koepp@club.be,Abe,Koepp,AbeK,399-268-9229,player,5,Wimbledon Ltc Club
-8,199,ramiro.dubuque@club.be,Ramiro,DuBuque,RamiroD,1-748-092-4490,player,5,Wimbledon Ltc Club
-9,203,sanford.schroeder@club.be,Sanford,Schroeder,SanfordS,307.820.8720,player,5,Wimbledon Ltc Club
-10,202,rueben.effertz@club.be,Rueben,Effertz,RuebenE,197.873.5236,player,5,Wimbledon Ltc Club
-11,200,kory.wyman@club.be,Kory,Wyman,KoryW,134-830-5270,player,5,Wimbledon Ltc Club
-12,198,lewis.luettgen@club.be,Lewis,Luettgen,LewisL,1-459-227-6481,player,5,Wimbledon Ltc Club
-13,212,hilario.d'amore@club.be,Hilario,D'Amore,HilarioD,(192) 705-6696,player,7,Wimbledon Ltc Club
-14,211,reyes.willms@club.be,Reyes,Willms,ReyesW,246.308.1655,player,7,Wimbledon Ltc Club
-15,213,rueben.mckenzie@club.be,Rueben,McKenzie,RuebenM,485.929.8431,player,7,Wimbledon Ltc Club
-16,215,tobias.nicolas@club.be,Tobias,Nicolas,TobiasN,815.454.2407,player,7,Wimbledon Ltc Club
-17,210,lindsay.jakubowski@club.be,Lindsay,Jakubowski,LindsayJ,862-054-8991,player,7,Wimbledon Ltc Club
-18,214,irvin.harvey@club.be,Irvin,Harvey,IrvinH,(215) 523-4931,player,7,Wimbledon Ltc Club
-19,222,carrol.o'conner@club.be,Carrol,O'Conner,CarrolO,(234) 690-6150,player,9,Wimbledon Ltc Club
-20,226,elmo.weimann@club.be,Elmo,Weimann,ElmoW,472-901-3571,player,9,Wimbledon Ltc Club
-21,225,rey.mills@club.be,Rey,Mills,ReyM,628-759-1271,player,9,Wimbledon Ltc Club
-22,227,lester.o'connell@club.be,Lester,O'Connell,LesterO,1-388-302-4503,player,9,Wimbledon Ltc Club
-23,224,jospeh.senger@club.be,Jospeh,Senger,JospehS,902-257-2953,player,9,Wimbledon Ltc Club
-24,223,royal.ondricka@club.be,Royal,Ondricka,RoyalO,(347) 477-4825,player,9,Wimbledon Ltc Club
-25,240,ron.pacocha@club.be,Ron,Pacocha,RonP,1-893-540-3542,player,12,Wimbledon Ltc Club
-26,244,lloyd.padberg@club.be,Lloyd,Padberg,LloydP,451-260-0736,player,12,Wimbledon Ltc Club
-27,241,miguel.sawayn@club.be,Miguel,Sawayn,MiguelS,514-435-5766,player,12,Wimbledon Ltc Club
-28,245,pat.johnson@club.be,Pat,Johnson,PatJ,564-187-9797,player,12,Wimbledon Ltc Club
-29,242,allen.spencer@club.be,Allen,Spencer,AllenS,1-665-888-2270,player,12,Wimbledon Ltc Club
-30,243,abel.kuvalis@club.be,Abel,Kuvalis,AbelK,521.533.5917,player,12,Wimbledon Ltc Club
-31,248,bryce.goodwin@club.be,Bryce,Goodwin,BryceG,1-434-167-4260,player,13,Wimbledon Ltc Club
-32,249,donald.denesik@club.be,Donald,Denesik,DonaldD,223-353-5022,player,13,Wimbledon Ltc Club
-33,250,ted.nienow@club.be,Ted,Nienow,TedN,499-926-5445,player,13,Wimbledon Ltc Club
-34,251,raleigh.reynolds@club.be,Raleigh,Reynolds,RaleighR,(949) 245-4681,player,13,Wimbledon Ltc Club
-35,246,wilmer.crist@club.be,Wilmer,Crist,WilmerC,185-870-5707,player,13,Wimbledon Ltc Club
-36,247,val.waelchi@club.be,Val,Waelchi,ValW,1-456-909-1058,player,13,Wimbledon Ltc Club
-37,257,lino.bins@club.be,Lino,Bins,LinoB,743-610-7675,player,14,Wimbledon Ltc Club
-38,253,wilburn.rippin@club.be,Wilburn,Rippin,WilburnR,1-959-739-9336,player,14,Wimbledon Ltc Club
-39,255,isreal.frami@club.be,Isreal,Frami,IsrealF,391-766-3539,player,14,Wimbledon Ltc Club
-40,254,rufus.lindgren@club.be,Rufus,Lindgren,RufusL,1-316-032-2068,player,14,Wimbledon Ltc Club
-41,256,truman.beer@club.be,Truman,Beer,TrumanB,(976) 082-9045,player,14,Wimbledon Ltc Club
-42,252,rudolph.morissette@club.be,Rudolph,Morissette,RudolphM,1-659-157-6829,player,14,Wimbledon Ltc Club
-43,195,nathaniel.mohr@club.be,Nathaniel,Mohr,NathanielM,(369) 553-3975,player,4,Wimbledon Ltc Club
-44,194,hobert.beier@club.be,Hobert,Beier,HobertB,391.824.3587,player,4,Wimbledon Ltc Club
-45,196,elvin.murazik@club.be,Elvin,Murazik,ElvinM,(970) 950-4938,player,4,Wimbledon Ltc Club
-46,197,russel.bechtelar@club.be,Russel,Bechtelar,RusselB,(394) 608-6881,player,4,Wimbledon Ltc Club
-47,192,albert.rosenbaum@club.be,Albert,Rosenbaum,AlbertR,(789) 744-9615,player,4,Wimbledon Ltc Club
-48,193,aurelio.auer@club.be,Aurelio,Auer,AurelioA,748.139.5371,player,4,Wimbledon Ltc Club
-49,206,jeffry.gottlieb@club.be,Jeffry,Gottlieb,JeffryG,(668) 874-4472,player,6,Wimbledon Ltc Club
-50,209,ahmad.mante@club.be,Ahmad,Mante,AhmadM,395-218-5037,player,6,Wimbledon Ltc Club
-51,205,val.kihn@club.be,Val,Kihn,ValK,1-925-238-4646,player,6,Wimbledon Ltc Club
-52,207,rodrick.witting@club.be,Rodrick,Witting,RodrickW,1-818-264-0346,player,6,Wimbledon Ltc Club
-53,208,valentin.abbott@club.be,Valentin,Abbott,ValentinA,(116) 503-1292,player,6,Wimbledon Ltc Club
-54,204,warner.corwin@club.be,Warner,Corwin,WarnerC,764.182.9683,player,6,Wimbledon Ltc Club
-55,235,rosendo.homenick@club.be,Rosendo,Homenick,RosendoH,185-129-3025,player,11,Wimbledon Ltc Club
-56,238,arturo.cassin@club.be,Arturo,Cassin,ArturoC,253.144.1419,player,11,Wimbledon Ltc Club
-57,234,stanley.vandervort@club.be,Stanley,Vandervort,StanleyV,(560) 882-4406,player,11,Wimbledon Ltc Club
-58,236,barrett.heidenreich@club.be,Barrett,Heidenreich,BarrettH,354-701-8016,player,11,Wimbledon Ltc Club
-59,237,leonel.lubowitz@club.be,Leonel,Lubowitz,LeonelL,1-306-401-8145,player,11,Wimbledon Ltc Club
-60,239,oscar.hudson@club.be,Oscar,Hudson,OscarH,525-415-6284,player,11,Wimbledon Ltc Club
-61,184,cedric.zemlak@club.be,Cedric,Zemlak,CedricZ,1-696-014-1741,player,2,Wimbledon Ltc Club
-62,181,weldon.ernser@club.be,Weldon,Ernser,WeldonE,1-159-284-4191,player,2,Wimbledon Ltc Club
-63,182,alfonzo.o'kon@club.be,Alfonzo,O'Kon,AlfonzoO,1-322-123-1832,player,2,Wimbledon Ltc Club
-64,185,glenn.raynor@club.be,Glenn,Raynor,GlennR,197.487.2456,player,2,Wimbledon Ltc Club
-65,183,moses.mccullough@club.be,Moses,McCullough,MosesM,847.700.9327,player,2,Wimbledon Ltc Club
-66,180,kendrick.bahringer@club.be,Kendrick,Bahringer,KendrickB,1-243-302-3856,player,2,Wimbledon Ltc Club
-67,230,andreas.mcdermott@club.be,Andreas,McDermott,AndreasM,1-353-543-7698,player,10,Wimbledon Ltc Club
-68,231,keneth.towne@club.be,Keneth,Towne,KenethT,1-314-847-1622,player,10,Wimbledon Ltc Club
-69,233,ollie.haley@club.be,Ollie,Haley,OllieH,1-484-754-4012,player,10,Wimbledon Ltc Club
-70,228,rubin.collier@club.be,Rubin,Collier,RubinC,(631) 953-8719,player,10,Wimbledon Ltc Club
-71,229,duncan.pfannerstill@club.be,Duncan,Pfannerstill,DuncanP,401.513.7379,player,10,Wimbledon Ltc Club
-72,232,horace.harber@club.be,Horace,Harber,HoraceH,803-380-5434,player,10,Wimbledon Ltc Club
-73,187,kristopher.cronin@club.be,Kristopher,Cronin,KristopherC,343.873.3324,player,3,Wimbledon Ltc Club
-74,186,dick.cartwright@club.be,Dick,Cartwright,DickC,984.155.2336,player,3,Wimbledon Ltc Club
-75,191,korey.hoeger@club.be,Korey,Hoeger,KoreyH,1-636-101-7747,player,3,Wimbledon Ltc Club
-76,190,johnathon.crooks@club.be,Johnathon,Crooks,JohnathonC,727.702.2774,player,3,Wimbledon Ltc Club
-77,188,graig.cruickshank@club.be,Graig,Cruickshank,GraigC,156-767-0361,player,3,Wimbledon Ltc Club
-78,189,parker.wisozk@club.be,Parker,Wisozk,ParkerW,798-121-3883,player,3,Wimbledon Ltc Club
-79,218,bradly.bergstrom@club.be,Bradly,Bergstrom,BradlyB,(735) 382-4780,player,8,Wimbledon Ltc Club
-80,216,luther.cormier@club.be,Luther,Cormier,LutherC,1-846-247-9230,player,8,Wimbledon Ltc Club
-81,219,dorian.osinski@club.be,Dorian,Osinski,DorianO,469.738.3506,player,8,Wimbledon Ltc Club
-82,220,robt.haag@club.be,Robt,Haag,RobtH,1-910-338-2490,player,8,Wimbledon Ltc Club
-83,217,octavio.wisoky@club.be,Octavio,Wisoky,OctavioW,(252) 498-2201,player,8,Wimbledon Ltc Club
-84,221,dong.metz@club.be,Dong,Metz,DongM,596-081-8298,player,8,Wimbledon Ltc Club
+id,club_id,email,first_name,last_name,nickname,phone_number,role
+191,5,korey.hoeger@club.be,Korey,Hoeger,KoreyH,1-636-101-7747,player
+186,5,dick.cartwright@club.be,Dick,Cartwright,DickC,984.155.2336,player
+179,5,frederick.nicolas@club.be,Frederick,Nicolas,FrederickN,(839) 348-5521,player
+174,5,frederic.brakus@club.be,Frederic,Brakus,FredericB,843-851-5544,player
+175,5,brent.emard@club.be,Brent,Emard,BrentE,602.155.5616,player
+178,5,stanton.schmidt@club.be,Stanton,Schmidt,StantonS,175-672-6053,player
+176,5,chuck.cartwright@club.be,Chuck,Cartwright,ChuckC,1-870-464-0847,player
+199,5,ramiro.dubuque@club.be,Ramiro,DuBuque,RamiroD,1-748-092-4490,player
+177,5,aurelio.boyle@club.be,Aurelio,Boyle,AurelioB,(565) 886-7164,player
+188,5,graig.cruickshank@club.be,Graig,Cruickshank,GraigC,156-767-0361,player
+198,5,lewis.luettgen@club.be,Lewis,Luettgen,LewisL,1-459-227-6481,player
+187,5,kristopher.cronin@club.be,Kristopher,Cronin,KristopherC,343.873.3324,player
+200,5,kory.wyman@club.be,Kory,Wyman,KoryW,134-830-5270,player
+189,5,parker.wisozk@club.be,Parker,Wisozk,ParkerW,798-121-3883,player
+214,5,irvin.harvey@club.be,Irvin,Harvey,IrvinH,(215) 523-4931,player
+202,5,rueben.effertz@club.be,Rueben,Effertz,RuebenE,197.873.5236,player
+190,5,johnathon.crooks@club.be,Johnathon,Crooks,JohnathonC,727.702.2774,player
+215,5,tobias.nicolas@club.be,Tobias,Nicolas,TobiasN,815.454.2407,player
+203,5,sanford.schroeder@club.be,Sanford,Schroeder,SanfordS,307.820.8720,player
+201,5,abe.koepp@club.be,Abe,Koepp,AbeK,399-268-9229,player
+216,5,luther.cormier@club.be,Luther,Cormier,LutherC,1-846-247-9230,player
+217,5,octavio.wisoky@club.be,Octavio,Wisoky,OctavioW,(252) 498-2201,player
+211,5,reyes.willms@club.be,Reyes,Willms,ReyesW,246.308.1655,player
+213,5,rueben.mckenzie@club.be,Rueben,McKenzie,RuebenM,485.929.8431,player
+218,5,bradly.bergstrom@club.be,Bradly,Bergstrom,BradlyB,(735) 382-4780,player
+222,5,carrol.o'conner@club.be,Carrol,O'Conner,CarrolO,(234) 690-6150,player
+212,5,hilario.d'amore@club.be,Hilario,D'Amore,HilarioD,(192) 705-6696,player
+223,5,royal.ondricka@club.be,Royal,Ondricka,RoyalO,(347) 477-4825,player
+210,5,lindsay.jakubowski@club.be,Lindsay,Jakubowski,LindsayJ,862-054-8991,player
+220,5,robt.haag@club.be,Robt,Haag,RobtH,1-910-338-2490,player
+221,5,dong.metz@club.be,Dong,Metz,DongM,596-081-8298,player
+225,5,rey.mills@club.be,Rey,Mills,ReyM,628-759-1271,player
+240,5,ron.pacocha@club.be,Ron,Pacocha,RonP,1-893-540-3542,player
+219,5,dorian.osinski@club.be,Dorian,Osinski,DorianO,469.738.3506,player
+226,5,elmo.weimann@club.be,Elmo,Weimann,ElmoW,472-901-3571,player
+244,5,lloyd.padberg@club.be,Lloyd,Padberg,LloydP,451-260-0736,player
+227,5,lester.o'connell@club.be,Lester,O'Connell,LesterO,1-388-302-4503,player
+245,5,pat.johnson@club.be,Pat,Johnson,PatJ,564-187-9797,player
+241,5,miguel.sawayn@club.be,Miguel,Sawayn,MiguelS,514-435-5766,player
+224,5,jospeh.senger@club.be,Jospeh,Senger,JospehS,902-257-2953,player
+248,5,bryce.goodwin@club.be,Bryce,Goodwin,BryceG,1-434-167-4260,player
+249,5,donald.denesik@club.be,Donald,Denesik,DonaldD,223-353-5022,player
+251,5,raleigh.reynolds@club.be,Raleigh,Reynolds,RaleighR,(949) 245-4681,player
+242,5,allen.spencer@club.be,Allen,Spencer,AllenS,1-665-888-2270,player
+246,5,wilmer.crist@club.be,Wilmer,Crist,WilmerC,185-870-5707,player
+250,5,ted.nienow@club.be,Ted,Nienow,TedN,499-926-5445,player
+247,5,val.waelchi@club.be,Val,Waelchi,ValW,1-456-909-1058,player
+243,5,abel.kuvalis@club.be,Abel,Kuvalis,AbelK,521.533.5917,player
+195,5,nathaniel.mohr@club.be,Nathaniel,Mohr,NathanielM,(369) 553-3975,player
+206,5,jeffry.gottlieb@club.be,Jeffry,Gottlieb,JeffryG,(668) 874-4472,player
+208,5,valentin.abbott@club.be,Valentin,Abbott,ValentinA,(116) 503-1292,player
+193,5,aurelio.auer@club.be,Aurelio,Auer,AurelioA,748.139.5371,player
+196,5,elvin.murazik@club.be,Elvin,Murazik,ElvinM,(970) 950-4938,player
+192,5,albert.rosenbaum@club.be,Albert,Rosenbaum,AlbertR,(789) 744-9615,player
+197,5,russel.bechtelar@club.be,Russel,Bechtelar,RusselB,(394) 608-6881,player
+209,5,ahmad.mante@club.be,Ahmad,Mante,AhmadM,395-218-5037,player
+207,5,rodrick.witting@club.be,Rodrick,Witting,RodrickW,1-818-264-0346,player
+182,5,alfonzo.o'kon@club.be,Alfonzo,O'Kon,AlfonzoO,1-322-123-1832,player
+204,5,warner.corwin@club.be,Warner,Corwin,WarnerC,764.182.9683,player
+194,5,hobert.beier@club.be,Hobert,Beier,HobertB,391.824.3587,player
+180,5,kendrick.bahringer@club.be,Kendrick,Bahringer,KendrickB,1-243-302-3856,player
+184,5,cedric.zemlak@club.be,Cedric,Zemlak,CedricZ,1-696-014-1741,player
+181,5,weldon.ernser@club.be,Weldon,Ernser,WeldonE,1-159-284-4191,player
+185,5,glenn.raynor@club.be,Glenn,Raynor,GlennR,197.487.2456,player
+183,5,moses.mccullough@club.be,Moses,McCullough,MosesM,847.700.9327,player
+173,5,philippe.dardenne@club.be,Philippe,Dardenne,PhilippeD,(32) 477 940 591,referee


### PR DESCRIPTION
In the new round creation form (rounds/new) added the option to attach a csv file containing players details for the new round.
If a file is attached, the shifts are not taken into account and new players may be included in the csv file, otherwise the players are taken from the last round and shifts are applied.
The CSV file must have the following headers : "id", "club_id", "email", "first_name", "last_name", "phone_number" and "role".

In the home index page added a condition on the numbers of days left in the round to let the request new round button appear on the screen. Admin may create new past rounds, Referees may request new round within 15 days of the end of the current round.