### PR TITLE
add form for any chatroom choice/creation in chatroom/show

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,7 +54,7 @@ class ApplicationController < ActionController::Base
   def set_club_round
     # instantiate variables @club from params[:club_id], and @round from params[:round_id]
     # if they have been selected from the _select_club_round forms
-    # invoked by #index, #my_scores in Boxes and user_box_scores/index views forms
+    # method called from #index, #my_scores in Boxes and user_box_scores/index views forms
     clubs = Club.all.reject { |club| club == @sample_club }
     @club_names = clubs.map(&:name) # dropdown list in the select_club form
 

--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -12,26 +12,49 @@ class ChatroomsController < ApplicationController
       @box_nb = @chatroom.box.box_number
       @round = @chatroom.box.round
       @round_nb = round_number(@round)
-    elsif params[:id] == "0" # coming from the navbar (admin/referee): create the dropdown list of chatrooms available
-      if current_user == @admin # admin: all existing chatrooms (including the #general chatroom)
-        @chatrooms = Chatroom.all
-      else # Referee: only chatrooms from his club + the #general chatroom
-        @chatrooms = Chatroom.select do |chatroom|
-          chatroom.box.round.club == current_user.club
-        end
-        @chatrooms.push(@general_chatroom) unless @chatrooms.include?(@general_chatroom)
+    elsif params[:box] # after selecting a club, a round and a box number, select or create a chatroom
+      club = Club.find_by(name: params[:club])
+      round = Round.find_by(club_id: club.id, start_date: params[:round].to_date)
+      @box = Box.find_by(box_number: params[:box], round_id: round.id)
+      chatroom_name = "#{@box.round.club.name} - R#{round_number(@box.round)}:B#{format('%02d', @box.box_number)}"
+      if Chatroom.find_by(name: chatroom_name)
+        @chatroom = Chatroom.find_by(name: chatroom_name)
+      else
+        flash[:notice] = t('.chatroom_created_flash')
+        @chatroom = Chatroom.create(name: chatroom_name)
+        @box.update(chatroom_id: @chatroom.id)
       end
-      # add the '#' character in front of the chatroom names (for displaying in the form)
-      @chatrooms = @chatrooms.map { |chatroom| "##{chatroom.name}" }
-      # @clubs = Club.all.reject { |club| club == @sample_club }
-    elsif Chatroom.exists?(params[:id])
-      # coming from the navbar or my_scores view page
-      @chatroom = Chatroom.find(params[:id])
       @box_nb = @chatroom.box.box_number
-      if @chatroom.box.user_box_scores.select { |user_box_score| user_box_score.user_id == current_user.id }.empty?
-        # chatroom not available to current user
-        flash[:notice] = t('.no_access_flash')
-        redirect_back(fallback_location: current_user.role == "player" ? my_scores_path(0) : root_path)
+      @round = @chatroom.box.round
+      @round_nb = round_number(@round)
+      # clean params when hitting back to reset the forms
+    elsif params[:id]
+      if params[:id] == "0" # coming from the navbar (admin/referee): create the dropdown list of chatrooms available
+        if current_user == @admin # admin: all existing chatrooms (including the #general chatroom)
+          @chatrooms = Chatroom.all
+        else # Referee: only chatrooms from his club + the #general chatroom
+          @chatrooms = Chatroom.select do |chatroom|
+            chatroom.box.round.club == current_user.club
+          end
+          @chatrooms.push(@general_chatroom) unless @chatrooms.include?(@general_chatroom)
+        end
+        # add the '#' character in front of the chatroom names (for displaying in the form)
+        @chatrooms = @chatrooms.map { |chatroom| "##{chatroom.name}" }
+        # create a hash containing clubs, rounds start_date and box numbers to prepare for the form
+        @data = Club.all.includes(rounds: :boxes).as_json(
+                        include: { rounds: { include: { boxes: { only: [:box_number] } }, only: [:start_date] } },
+                        only: [:id, :name])
+        # transform the hash {"round" => value} to {round: value}
+        @data.each { |field| field.deep_symbolize_keys! }.reject! { |a| a[:id] == @sample_club.id }
+        @clubs = @data.map { |club| club[:name] }  #TO DO = for a referee set the club (no club form)
+      elsif Chatroom.exists?(params[:id]) # coming from the navbar or my_scores view page
+        @chatroom = Chatroom.find(params[:id])
+        @box_nb = @chatroom.box.box_number
+        if @chatroom.box.user_box_scores.select { |user_box_score| user_box_score.user_id == current_user.id }.empty?
+          # chatroom not available to current user
+          flash[:notice] = t('.no_access_flash')
+          redirect_back(fallback_location: current_user.role == "player" ? my_scores_path(0) : root_path)
+        end
       end
     else
       # chatroom Id does not exist

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -49,16 +49,75 @@ a chatroom is created in Box controller #my_scores.
   </div>
 <% else %>
   <!-- referees and admin get to select a chatroom -->
-  <div class="container text-size">
+  <div class="<%= class_names("text-size", "container": !@is_mobile) %>">
     <br><h3><%= t(".chatrooms_title", club: current_user == @admin ? "" : current_user.club.name).strip.titleize %></h3>
-    <div class="players frame-padding text-size">
+    <h5><%= t(".chatroom_choice") %></h5>
+    <div class="frame-color-shape frame-padding text-size">
+      <br>
       <%= form_with url: chatroom_path, method: :get do |form| %>
+        <%# choose existing chatroom from list of names %>
         <%= form.label :chatroom, t(".chose_chatroom") %>
-        &nbsp;&nbsp;&nbsp;&nbsp;<%= form.select :chatroom, @chatrooms.sort %>
-        &nbsp;&nbsp;&nbsp;&nbsp;<%= form.submit t(".confirm_btn"), class: "btn buttons-shape btn-green", name: "" %>
+        &nbsp;&nbsp;&nbsp;&nbsp;<%= form.select(:chatroom, @chatrooms.sort.unshift(t(".chatroom_name")), {selected: "chatroom"}, {onchange: "this.form.submit();"}) %>
+        <%# form.submit t(".confirm_btn"), class: "btn buttons-shape btn-green", name: "" %>
+        <%# form.select(:round_id, @start_dates, {selected: @selected_date}, {onchange: "this.form.submit();"}) %>&nbsp;&nbsp;&nbsp;&nbsp;
       <% end %>
+      <br><b><%= t(".or") %>:</b><br><br>
+      <%= t(".new_chatroom") %><br>
+      <% if current_user == @admin %>
+        <%= form_with url: chatroom_path, method: :get do |form| %>
+          <%# as some chatrooms are not open yet, select a club (admin) %>
+          <div class="row">
+            <div class="col-1"></div>
+            <div class="col-2"><%= form.label :club, t(".club") %></div>
+            <div class="col-3">
+              <%= form.select(:club, @clubs.unshift("club"), {selected: params[:club] ? params[:club] : "club"}, {onchange: "this.form.submit();"}) %>
+            </div>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="row">
+          <div class="col-1"></div>
+          <div class="col-2"><%= "Club" %></div>
+          <div class="col-3">
+            <%= current_user.club.name %>
+          </div>
+        </div>
+        <% params[:club] = current_user.club.name %>
+      <% end %>
+      <% if params[:club] %>
+        <% club_index = @data.index {|club| club[:name] == params[:club]}
+            rounds = @data[club_index][:rounds].map{|round| round[:start_date]}.sort %>
+        <%= form_with url: chatroom_path, method: :get do |form| %>
+          <%# select a round in the selected club %>
+        <div class="row">
+          <div class="col-1"></div>
+          <div class="col-2"><%= form.label :round, t(".round") %></div>
+          <div class="col-3">
+            <%= form.select(:round, rounds.unshift("round"), {selected: params[:round] ? params[:round] : "round"}, {onchange: "this.form.submit();"}) %>
+          </div>
+          <%= hidden_field_tag(:club, params[:club]) %>
+        </div>
+        <% end %>
+      <% end %>
+      <% if params[:round] %>
+        <% club_index = @data.index {|club| club[:name] == params[:club]}
+           round_index = @data[club_index][:rounds].index {|round| round[:start_date] == params[:round]}
+           boxes = @data[club_index][:rounds][round_index][:boxes].map{|box| box[:box_number]}.sort %>
+        <%= form_with url: chatroom_path, method: :get do |form| %>
+          <%# select a box in the selected round %>
+        <div class="row">
+          <div class="col-1"></div>
+          <div class="col-2"><%= form.label :box, t(".box") %></div>
+          <div class="col-3">
+            <%= form.select(:box, boxes.unshift("box"), {selected: "box"}, {onchange: "this.form.submit();"}) %>
+          </div>
+          <%= hidden_field_tag(:club, params[:club]) %>
+          <%= hidden_field_tag(:round, params[:round]) %>
+        </div>
+        <% end %>
+      <% end %>
+      <br>
     </div>
-    <%# TO DO : add form to create chatroom if it does not exist yet %>
   </div>
 <% end %>
 <br>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -10,7 +10,7 @@
     <%= render "shared/fullname", user: @player %><%= "(# #{player_ubs.rank})" %><i> versus</i>
     <%= render "shared/fullname", user: @opponent %><%= "(# #{opponent_ubs.rank})" %>
   </h5>
-    <div class="frame-color-shape frame-padding frame-margin-rl text-size">
+  <div class="frame-color-shape frame-padding frame-margin-rl text-size">
     <br>
     <% tiebreak = @player_match_score.score_tiebreak + @opponent_match_score.score_tiebreak %>
     <div class="<%=class_names( "mobile-grid-container mobile-score-width mobile-text-size": @is_mobile,

--- a/app/views/user_box_scores/_select_year.html.erb
+++ b/app/views/user_box_scores/_select_year.html.erb
@@ -7,7 +7,7 @@
       <%= form.label :round_year, local_assigns[:label] ? label : t('.select_round_year') %>
       <%= form.select(:round_year, @round_years.unshift(t('.year_dropdown')), {selected: params[:round_year]}, {onchange: "this.form.submit();"}) %>&nbsp;&nbsp;&nbsp;&nbsp;
     <% else %>
-      <%= form.label :round_year, local_assigns[:label] ? label : t('.select_round_year')+t('.year_dropdown') %>
+      <%= form.label :round_year, local_assigns[:label] ? label : t('.select_round_year')+" "+t('.year_dropdown') %>
       <%= form.select(:round_year, @round_years, {selected: params[:round_year]}, {onchange: "this.form.submit();"}) %>&nbsp;&nbsp;&nbsp;&nbsp;
     <% end %>
   <% end %>

--- a/config/locales/views/chatrooms/en.yml
+++ b/config/locales/views/chatrooms/en.yml
@@ -13,8 +13,16 @@ en:
       message_invite: "> Message to"
       send_btn: ⎷ Send
       back_btn: ←
-      chose_chatroom: "Chose a chatroom: "
+      chatroom_choice: Access a chatroom
+      chose_chatroom: "Choose an existing chatroom: "
+      chatroom_name: Name of the chatroom
       confirm_btn: ⎷ Confirm
       chatrooms_title: "%{club} chatrooms"
       no_access_flash: You have no access to this chatroom
       no_chatroom_flash: This chatroom does not exist
+      or: or
+      new_chatroom: "Open a chatroom: "
+      club: Club choice
+      round: Round start date
+      box: Box number
+      chatroom_created_flash: New chatroom created

--- a/config/locales/views/chatrooms/fr.yml
+++ b/config/locales/views/chatrooms/fr.yml
@@ -13,8 +13,16 @@ fr:
       message_invite: "> Message vers"
       send_btn: ⎷ Envoi
       back_btn: ←
-      chose_chatroom: "Choisir une chatroom: "
+      chatroom_choice: Accéder à une chatroom
+      chose_chatroom: "Choisir une chatroom existante: "
+      chatroom_name: Nom de la chatroom
       confirm_btn: ⎷ Confirmer
       chatrooms_title: "Chatrooms %{club}"
       no_access_flash: Vous n'avez pas accès à cette chatroom
       no_chatroom_flash: Cette chatroom n'existe pas
+      or: ou
+      new_chatroom: "Ouvrir une chatroom: "
+      club: Choix du club
+      round: Début du round
+      box: Numéro de box
+      chatroom_created_flash: Création d'une nouvelle chatroom

--- a/config/locales/views/chatrooms/nl.yml
+++ b/config/locales/views/chatrooms/nl.yml
@@ -13,8 +13,16 @@ nl:
       message_invite: "> Bericht naar"
       send_btn: ⎷ Versturen
       back_btn: ←
-      chose_chatroom: "Kies een chatroom: "
+      chatroom_choice: Toegang tot een chatroom
+      chose_chatroom: "Kies een bestaande chatroom: "
+      chatroom_name: Chatroom naam
       confirm_btn: ⎷ Bevestigen
       chatrooms_title: "Chatrooms %{club}"
       no_access_flash: U heeft geen toegang tot deze chatroom
       no_chatroom_flash: Deze chatroom bestaat niet
+      or: of
+      new_chatroom: "Open een chatroom: "
+      club: Kies een club
+      round: Start van de ronde
+      box: Box nummer
+      chatroom_created_flash: Newe chatroom gemaakt

--- a/config/locales/views/user_box_scores/fr.yml
+++ b/config/locales/views/user_box_scores/fr.yml
@@ -9,7 +9,7 @@ fr:
       league_table_title: League table de l'année
       valid_year_flash: "League table annuelle: choisir une année valide"
     select_year:
-      select_round_year: League table de l'
+      select_round_year: League table annuelle
       year_dropdown: année
     top_line:
       top_line_html: >

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,7 @@
 # # set as true to append new round to existing clubs
 # new_round = false
 
+# 1/ seeding 2 clubs, players, referees, rounds, boxes, user_box_scores, courts
 # if true
 #   # if Rails.env.development?
 #     puts "-------------------"
@@ -190,30 +191,47 @@
 #   end
 # end
 
-# populate columns games_won and games_played in UserBoxScore records (empty from new migration 29/1/2024)
-UserBoxScore.update_all(games_won: 0, games_played: 0)
 
-Match.all.each do |match|
-  user_match_scores = match.user_match_scores
-  ums = user_match_scores[0] # player
-  oms = user_match_scores[1] # opponent
-  ubs = UserBoxScore.find_by(user_id: ums.user.id, box_id: ums.match.box.id)
-  puts "UMS id #{ums.id}, #{ums.score_set1}  #{ums.score_set2}  #{ums.score_tiebreak}"
-  puts "OMS id #{oms.id}, #{oms.score_set1}  #{oms.score_set2}  #{oms.score_tiebreak}"
-  ubs.games_won += ums.score_set1 + ums.score_set2 + ums.score_tiebreak
-  ubs.games_played += ums.score_set1 + ums.score_set2 + ums.score_tiebreak +
-                      oms.score_set1 + oms.score_set2 + oms.score_tiebreak
-  puts "  > UBS id: #{ubs.id}, games won    #{ubs.games_won}"
-  puts "  > UBS id: #{ubs.id}, games played #{ubs.games_played}"
-  puts ""
-  puts ubs.save
 
-  obs = UserBoxScore.find_by(user_id: oms.user.id, box_id: oms.match.box.id)
-  obs.games_won += oms.score_set1 + oms.score_set2 + oms.score_tiebreak
-  obs.games_played += ums.score_set1 + ums.score_set2 + ums.score_tiebreak +
-                      oms.score_set1 + oms.score_set2 + oms.score_tiebreak
-  puts "  > OBS id: #{obs.id}, games won    #{obs.games_won}"
-  puts "  > OBS id: #{obs.id}, games played #{obs.games_played}"
-  puts obs.save
-  puts "------------------------------------"
+
+
+# 2/ populate columns games_won and games_played in UserBoxScore records (empty from new migration 29/1/2024)
+# UserBoxScore.update_all(games_won: 0, games_played: 0)
+
+# Match.all.each do |match|
+#   user_match_scores = match.user_match_scores
+#   ums = user_match_scores[0] # player
+#   oms = user_match_scores[1] # opponent
+#   ubs = UserBoxScore.find_by(user_id: ums.user.id, box_id: ums.match.box.id)
+#   puts "UMS id #{ums.id}, #{ums.score_set1}  #{ums.score_set2}  #{ums.score_tiebreak}"
+#   puts "OMS id #{oms.id}, #{oms.score_set1}  #{oms.score_set2}  #{oms.score_tiebreak}"
+#   ubs.games_won += ums.score_set1 + ums.score_set2 + ums.score_tiebreak
+#   ubs.games_played += ums.score_set1 + ums.score_set2 + ums.score_tiebreak +
+#                       oms.score_set1 + oms.score_set2 + oms.score_tiebreak
+#   puts "  > UBS id: #{ubs.id}, games won    #{ubs.games_won}"
+#   puts "  > UBS id: #{ubs.id}, games played #{ubs.games_played}"
+#   puts ""
+#   puts ubs.save
+
+#   obs = UserBoxScore.find_by(user_id: oms.user.id, box_id: oms.match.box.id)
+#   obs.games_won += oms.score_set1 + oms.score_set2 + oms.score_tiebreak
+#   obs.games_played += ums.score_set1 + ums.score_set2 + ums.score_tiebreak +
+#                       oms.score_set1 + oms.score_set2 + oms.score_tiebreak
+#   puts "  > OBS id: #{obs.id}, games won    #{obs.games_won}"
+#   puts "  > OBS id: #{obs.id}, games played #{obs.games_played}"
+#   puts obs.save
+#   puts "------------------------------------"
+# end
+
+# 3/ rename chatrooms from eg: "Wimbledon Ltc Club - B04/R23_03" to "Wimbledon Ltc Club - R23_03:B04"
+general = Chatroom.find_by(name: "general")
+chatrooms = Chatroom.excluding(general)
+
+chatrooms.each do |chatroom|
+  puts "Chatroom id: #{chatroom.id}, old name: #{chatroom.name}"
+  roundname = chatroom.name[-6, 6]
+  boxname = chatroom.name[-10, 3]
+  newname = "#{chatroom.name[0, chatroom.name.size - 10]}#{roundname}:#{boxname}"
+  chatroom.update(name: newname)
+  puts ">> new name: #{chatroom.name}"
 end


### PR DESCRIPTION
Admin / referees may now (from the navbar menu to chatrooms/show) either select an existing chatroom by its name, of chose club/round/box to access or create the corresponding chatroom.
The nested forms could be done thanks to storing the available choices into a hash:
        @data = Club.all.includes(rounds: :boxes).as_json(
                        include: { rounds: { include: { boxes: { only: [:box_number] } }, only: [:start_date] } },
                        only: [:id, :name])
        # transform the hash {"round" => value} to {round: value}
        @data.each { |field| field.deep_symbolize_keys! }.reject! { |a| a[:id] == @sample_club.id }
