### PR TITLE
fix chatroom and round edit access

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -232,7 +232,7 @@ class ApplicationController < ActionController::Base
 
   def round_label(round)
     # returns round label in format "yy/mm_Rnn" where
-    # yy/mm is the tourament start date and nn is the rank of the round in the tournament
+    # yy/mm is the tournament start date and nn is the rank of the round in the tournament
     league_start = round.league_start
     rounds_ordered = Round.where(league_start:, club_id: round.club)
                           .order('start_date ASC')
@@ -262,9 +262,10 @@ class ApplicationController < ActionController::Base
   end
 
   def init_stats
+    # set the global statistic variables for the stats to be displayed in the view pages
     @nb_matches = @round.boxes.map { |box| box.user_box_scores.count * (box.user_box_scores.count - 1) / 2 }.sum
     @nb_matches_played = @round.boxes.map { |box| box.matches.count }.sum
-    @elapsed_days = @round.end_date - Date.today
+    @days_left = @round.end_date - Date.today
     @round_days = @round.end_date - @round.start_date
     @nb_boxes = @round.boxes.count
     @nb_players = @round.boxes.map { |box| box.user_box_scores.count }.sum
@@ -275,5 +276,10 @@ class ApplicationController < ActionController::Base
       @my_nb_matches = @my_current_box.user_box_scores.count - 1
       @my_nb_matches_played = current_user.user_match_scores.select { |user_match_score| user_match_score.match.box == @my_current_box }.map(&:match).count
     end
+  end
+
+  def chatroom_name(box)
+    # for a given box, return the chatroom name
+    "#{box.round.club.name} - #{round_label(box.round)}:B#{format('%02d', box.box_number)}"
   end
 end

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -77,7 +77,7 @@ class BoxesController < ApplicationController
         # The name format: "[Club name] - R[Round id]:B[Box number]"
         # a chatroom is box and round specific:
         # players can access it when visiting My Scores or from the navbar menu Chatrooms
-        @chatroom = Chatroom.create(name: "#{@box.round.club.name} - R#{round_label(@box.round)}:B#{format('%02d', @box.box_number)}")
+        @chatroom = Chatroom.create(name: chatroom_name(@box))
         @box.update(chatroom_id: @chatroom.id)
       else
         @chatroom = @box.chatroom

--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -24,7 +24,7 @@ class ChatroomsController < ApplicationController
       else
         @box = Box.find_by(box_number: params[:box], round_id: round.id) # admin/referees choose a box number
       end
-      chatroom_name = "#{@box.round.club.name} - R#{round_label(@box.round)}:B#{format('%02d', @box.box_number)}"
+      chatroom_name = chatroom_name(@box)
       if Chatroom.find_by(name: chatroom_name)
         # chatroom already open, select it
         @chatroom = Chatroom.find_by(name: chatroom_name)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,7 +10,8 @@ class PagesController < ApplicationController
       @path["02"] = boxes_path
       @path["03a"] = box_list_path(@box || 0)
       @path["03b"] = box_path(@box || 0)
-      @path["04"] = user_box_scores_path
+      @path["04a"] = user_box_scores_path
+      @path["04b"] = index_league_path
     end
     @path["05"] = rules_path
   end

--- a/app/controllers/user_box_scores_controller.rb
+++ b/app/controllers/user_box_scores_controller.rb
@@ -29,10 +29,10 @@ class UserBoxScoresController < ApplicationController
       init_stats
       case params[:sort].to_i
       when 1 # "Player first name"
-        @user_box_scores = @round.user_box_scores.sort_by { |user_bs| [user_bs.user.first_name, -@order * user_bs.rank] }
+        @user_box_scores = @round.user_box_scores.sort_by { |user_bs| [user_bs.user.first_name.upcase, -@order * user_bs.rank] }
         @user_box_scores.reverse! if @order == 1
       when 2 # "Player last name"
-        @user_box_scores = @round.user_box_scores.sort_by { |user_bs| [user_bs.user.last_name, -@order * user_bs.rank] }
+        @user_box_scores = @round.user_box_scores.sort_by { |user_bs| [user_bs.user.last_name.upcase, -@order * user_bs.rank] }
         @user_box_scores.reverse! if @order == 1
       when 3 # "Ranking: default sorting order"
       when 4 # "Points"
@@ -90,10 +90,10 @@ class UserBoxScoresController < ApplicationController
         @sort = params[:sort]
         case params[:sort].to_i
         when 1 # "Player first name"
-          @user_box_scores.sort_by! { |user_bs| [user_bs[0].first_name, -@order * user_bs[1][:rank]] }
+          @user_box_scores.sort_by! { |user_bs| [user_bs[0].first_name.upcase, -@order * user_bs[1][:rank]] }
           @user_box_scores.reverse! if @order == 1
         when 2 # "Player last name"
-          @user_box_scores.sort_by! { |user_bs| [user_bs[0].last_name, -@order * user_bs[1][:rank]] }
+          @user_box_scores.sort_by! { |user_bs| [user_bs[0].last_name.upcase, -@order * user_bs[1][:rank]] }
           @user_box_scores.reverse! if @order == 1
         when 3 # "Ranking: default sorting order"
         when 4 # "Points"

--- a/app/views/boxes/index.html.erb
+++ b/app/views/boxes/index.html.erb
@@ -9,13 +9,13 @@
     <div class = "one-liner">
       <h4><%= render "shared/display_club", round: @round, fallback_path: boxes_path, add_text: "" %></h4>
       <div>
+        <% if current_user && current_user.role != "player" %>
+          <%= link_to t('.to_csv_btn'), csv_boxes_path(round_id: @round.id), class: "btn buttons-shape btn-green dont-print mb-3" %>
+        <% end %>
         <%= link_to t('print_btn'), '#', :onclick => 'window.print();return false;', class: "btn buttons-shape btn-green dont-print mb-3"%>
         <%= render 'shared/stats' %>
       </div>
       <%= render "shared/select_round", fallback_path: boxes_path %>
-      <% if current_user == @admin %>
-        <%= link_to "load_scores", load_scores_path(round_id: @round.id), class: "btn buttons-shape btn-aqua" %>
-      <% end %>
     </div>
     <div data-controller="popover" data-bs-html="true" data-bs-toggle="popover"
         data-bs-trigger="hover" data-bs-placement="right" data-bs-delay= '{"show": 1000}'
@@ -44,9 +44,8 @@
     </div>
 
     <div class="buttons-wrap dont-print">
-      <% if current_user && current_user.role != "player" %>
-        <%= link_to t('.to_csv_btn'), csv_boxes_path(round_id: @round.id), class: "btn buttons-shape btn-green dont-print text-size" %>
-        &nbsp;&nbsp;&nbsp;&nbsp;
+      <% if current_user == @admin %>
+        <%= link_to "load_scores", load_scores_path(round_id: @round.id), class: "btn buttons-shape btn-aqua" %>
       <% end %>
       <% if current_user && current_user.role == "admin" && @new_round_required %>
           <!-- allow referee/admin to create next round up to 15 days before or 300 days after end of last round

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -18,7 +18,7 @@ a chatroom is created in Box controller #my_scores.
       #<%= t(".chatroom_title", chatroom: @chatroom.name) %>
       <div>
         <%= link_to t('.back_btn'), :back, class: "btn buttons-shape btn-yellow dont-print" %>
-        <%= link_to t('print_btn'), '#', :onclick => 'window.print();return false;', class: "btn buttons-shape btn-green dont-print"%>
+        <%= link_to t('print_btn'), '#', onclick: 'window.print();return false;', class: "btn buttons-shape btn-green dont-print"%>
       </div>
     </h5>
     <div class="frame-color-shape chatroom-frame">
@@ -50,11 +50,12 @@ a chatroom is created in Box controller #my_scores.
 <% else %>
   <!-- select a chatroom from the forms -->
   <div class="<%= class_names("text-size", "container": !@is_mobile) %>">
-    <% unless current_user.role == "admin" %>
+    <% unless (["admin", "referee", "player referee"].include?(current_user.role)) %>
       <br><br><%= t '.not_authorised' %>
     <% else %>
+      <% suffix = current_user.role.split.map(&:capitalize).join.underscore %>
       <br><h3><%= t(".chatrooms_title", club: current_user == @admin ? "" : current_user.club.name).strip.titleize %></h3>
-      <h5><%= t(".chatroom_choice") %></h5>
+      <h5><%= t(".chatroom_choice") %> <%= "#{t('.message2_box_pop')} #{t(".message2_box_pop_#{suffix}")}" %></h5>
       <div class="frame-color-shape frame-padding frame-margin-rl text-size">
         <br>
         <%# form 1: choose an existing chatroom from a list of chatroom names %>
@@ -72,10 +73,10 @@ a chatroom is created in Box controller #my_scores.
         </div>
         <br><b><%= t(".or") %>:</b><br><br>
 
-        <%# form 2: select a club, a round and a box to open the corresponding chatroom, or create it %>
+        <%# form 2: select a club, a round and a box to open or create the corresponding chatroom %>
         <div data-controller="popover" data-bs-html="true" data-bs-toggle="popover"
         data-bs-trigger="hover focus" data-bs-placement="bottom" data-html="true" data-bs-delay= '{ "show": 500 }'
-        data-bs-content="<%= "#{t('.message2_box_pop')} #{t(".message2_box_pop_#{current_user.role}")}" %>">
+        data-bs-content="<%= "#{t('.message2_box_pop').capitalize} #{t(".message2_box_pop_#{suffix}")}" %>">
           <%= t(".new_chatroom") %><br>
           <% if current_user == @admin %>
             <%= form_with url: chatroom_path, method: :get do |form| %>
@@ -87,7 +88,7 @@ a chatroom is created in Box controller #my_scores.
                 </div>
               </div>
             <% end %>
-          <% else %> <%# current user is a referee or a player: club is set %>
+          <% else %> <%# if current user is a referee or a player, a club is set %>
             <div class="row">
               <div class="col-1"></div>
               <div class="col-11">
@@ -110,7 +111,7 @@ a chatroom is created in Box controller #my_scores.
                     <%# display round number in RYY_NN format %>
                     <% club = Club.find_by(name: params[:club])
                       round = Round.find_by(club_id: club.id, start_date: params[:round].to_date) %>
-                    => R<%= round_label(round) %>
+                    <%= "=> round R#{round_label(round)}" %>
                   <% end %>
                 </div>
                 <%= hidden_field_tag(:club, params[:club]) %>

--- a/app/views/matches/_match_winner.html.erb
+++ b/app/views/matches/_match_winner.html.erb
@@ -1,1 +1,0 @@
-<%= "#{t(".winner")}" %> <%= render "shared/fullname", user: winner %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -9,25 +9,26 @@
     <h5><b><%= t '.welcome_title' %></b></h5>
     <p><%= t '.p01' %></p>
     <p><%= t '.p02' %></p>
-    <p><%= t '.p03' %></p>
+    <p><%= t '.p03_html' %></p>
     <br>
 
     <br><h5 class="top-bottom-padding"><b><%= t '.use_title' %></b></h5>
-    <p><%= t '.p06' %></p>
     <ol><% if !current_user
       class_prefix = "bold-font color-" %>
-      <li class="top-bottom-padding"><%= t(".li05_html", inset: "<span class='#{class_prefix}tennis-red'>#{t ".li01"}</span>".html_safe) %></li>
       <li class="top-bottom-padding"><%= t(".li06_html", inset: "<span class='#{class_prefix}green'>#{t ".li02"}</span>".html_safe) %></li>
       <li class="top-bottom-padding"><%= t(".li07_html", inset_a: "<span class='#{class_prefix}tennis-blue'>#{t ".li03a"}</span>".html_safe,
-                                                        inset_b: "<span class='#{class_prefix}tennis-blue'>#{t ".li03b"}</span>".html_safe) %></li>
-      <li class="top-bottom-padding"><%= t(".li05_html", inset: "<span class='#{class_prefix}green'>#{t ".li04"}</span>".html_safe) %></li>
+                                                        inset_b: "<span class='#{class_prefix}tennis-blue'>#{t ".li03b"}</span>".html_safe,
+                                                        inset_c: "<span class='#{class_prefix}tennis-red'>#{t ".li01"}</span>".html_safe) %></li>
+      <li class="top-bottom-padding"><%= t(".li08_html", inset_a: "<span class='#{class_prefix}green'>#{t ".li04a"}</span>".html_safe,
+                                                        inset_b: "<span class='#{class_prefix}green'>#{t ".li04b"}</span>".html_safe) %></li>
     <% else
       class_prefix = "btn btn-inlayed bold-font color-" %>
-      <li class="top-bottom-padding"><%= t(".li05_html", inset: "<a class='#{class_prefix}tennis-red' href='#{@path["01"]}'>#{t ".li01"}</a>".html_safe) %></li>
       <li class="top-bottom-padding"><%= t(".li06_html", inset: "<a class='#{class_prefix}green' href='#{@path["02"]}'>#{t ".li02"}</a>".html_safe) %></li>
       <li class="top-bottom-padding"><%= t(".li07_html", inset_a: "<a class='#{class_prefix}tennis-blue' href='#{@path["03a"]}'>#{t ".li03a"}</a>".html_safe,
-                                                        inset_b: "<a class='#{class_prefix}tennis-blue' href='#{@path["03b"]}'>#{t ".li03b"}</a>".html_safe) %></li>
-      <li class="top-bottom-padding"><%= t(".li08_html", inset: "<a class='#{class_prefix}green' href='#{@path["04"]}'>#{t ".li04"}</a>".html_safe) %></li>
+                                                        inset_b: "<a class='#{class_prefix}tennis-blue' href='#{@path["03b"]}'>#{t ".li03b"}</a>".html_safe,
+                                                        inset_c: "<a class='#{class_prefix}tennis-red' href='#{@path["01"]}'>#{t ".li01"}</a>".html_safe) %></li>
+      <li class="top-bottom-padding"><%= t(".li08_html", inset_a: "<a class='#{class_prefix}green' href='#{@path["04a"]}'>#{t ".li04a"}</a>".html_safe,
+                                                        inset_b: "<a class='#{class_prefix}green' href='#{@path["04b"]}'>#{t ".li04b"}</a>".html_safe) %></li>
     <% end %></ol><br>
 
     <br><h5 class="top-bottom-padding"><b><%= t '.how_title' %></b></h5>

--- a/app/views/rounds/edit.html.erb
+++ b/app/views/rounds/edit.html.erb
@@ -1,10 +1,11 @@
 <div class="<%= class_names("text-size", "container": !@is_mobile) %>">
   <!-- admin/referee: modify the round end date. Accessed from navbar dropdown menu -->
-  <% unless current_user.role == "admin" %>
+  <% unless (["admin", "referee", "player referee"].include?(current_user.role)) %>
     <br><br><%= t '.not_authorised' %>
   <% else %>
     <% if !@is_mobile %><br><% end %>
     <h3><%= t '.round_end_title' %></h3>
+    <h5><%= t '.change_end_date' %></h5>
     <div class="frame-color-shape frame-padding frame-margin-rl">
     <% if current_user == @admin && !params[:club]%>
       <%= form_with url: edit_round_path, method: :get do |form| %>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -3,8 +3,8 @@ message = t(".line1",
     start: l(@round.start_date, format: :ddmmm_date),
     end: l(@round.end_date, format: :ddmmmyyy_date))
 message += t('.line2', players: @nb_players, boxes: @nb_boxes)
-if @elapsed_days.positive?
-  message += t('.line3', days_left: @elapsed_days.to_i, total_days: @round_days.to_i, ratio: format("%.1f", 100 - 100*@elapsed_days.to_f/@round_days))
+if @days_left.positive?
+  message += t('.line3', count: @days_left.to_i, total_days: @round_days.to_i, ratio: format("%.1f", 100 - 100*@days_left.to_f/@round_days))
 else
   message += t('.round_expired')
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  print_btn: Print
+  print_btn: 🖨 print
   points:
     zero: 0 points
     one: 1 point
@@ -64,7 +64,7 @@ en:
       wwwddmmm_at_hhmm: "%a %-d %b, %H:%M"
       wwwddmmmyy_at_hhmm: "%A %-d %b %Y, %H:%M"
 fr:
-  print_btn: Imprimer
+  print_btn: 🖨 imprimer
   points:
     zero: 0 point
     one: 1 point
@@ -111,7 +111,7 @@ fr:
     am: 'am'
     pm: 'pm'
 nl:
-  print_btn: Afdrukken
+  print_btn: 🖨 afdrukken
   points:
     zero: 0 punten
     one: 1 punt

--- a/config/locales/views/boxes/en.yml
+++ b/config/locales/views/boxes/en.yml
@@ -15,12 +15,12 @@ en:
     index:
       all_box_title: All boxes
       intro: "At a glance, see all the players' <b>name</b>, <b>ranking</b>, number of <b>played games</b>, and their <b>cumulated box points</b><br />"
-      message_box_pop: <b>Box columns:</b><br />Player name, rank,<br />nb of games played, box points earned.<br /><br />Click on a box to view match details
+      message_box_pop: <b>Box columns:</b><br />Player name, player rank,<br />nb of games played, box points earned.<br /><br />Click on a box to view match details
       my_current_box: (my current box)
       create_round_btn: Create the next round
       request_round_btn: Request the admin the next round
       valid_round_flash: "League table: choose a valid round"
-      to_csv_btn: Export to CSV file
+      to_csv_btn: 📄 CSV file
     my_scores:
       my_scores: My scores
       intro_html: >

--- a/config/locales/views/boxes/fr.yml
+++ b/config/locales/views/boxes/fr.yml
@@ -20,7 +20,7 @@ fr:
       create_round_btn: ⎷ Créer le prochain round
       request_round_btn: Demander la création du prochain round
       valid_round_flash: "League table annuel: choisir un round valide"
-      to_csv_btn: Exporter en CSV
+      to_csv_btn: 📄 fichier CSV
     my_scores:
       my_scores: Mes scores
       intro_html: >

--- a/config/locales/views/boxes/nl.yml
+++ b/config/locales/views/boxes/nl.yml
@@ -20,7 +20,7 @@ nl:
       create_round_btn: ⎷ Maak de volgende ronde
       request_round_btn: Vraag de admin de volgende ronde aan
       valid_round_flash: Kies een geldig rond.
-      to_csv_btn: Exporteren naar CSV-bestand
+      to_csv_btn: 📄 naar CSV-bestand
     my_scores:
       my_scores: Mijn scores
       intro_html: >

--- a/config/locales/views/chatrooms/en.yml
+++ b/config/locales/views/chatrooms/en.yml
@@ -14,7 +14,7 @@ en:
       message_invite: "> Message to"
       send_btn: ⎷ Send
       back_btn: ←
-      chatroom_choice: Access a chatroom
+      chatroom_choice: Access an open chatroom, or
       chose_chatroom: "Choose an open chatroom: "
       chatroom_name: Chatroom name
       confirm_btn: ⎷ Confirm
@@ -28,10 +28,13 @@ en:
       box: Box number
       chatroom_created_flash: New chatroom created
       message1_box_pop: >
-        The chatrooms names :<br />
-        #[Club] - R[YY_NN]:B[Box nb]<br />
-        YY_NN is the round number (YY is the round's year, NN the round rank in the year)
-      message2_box_pop: Open a chatroom by selecting
+        Chatroom name format :<br />
+        #[ClubName] - yyyy/mm_Rnn:Bbb<br /><br />
+        yyyy/mm : tournament year/month,<br />
+        nn : round number,<br />
+        bb : box number.
+      message2_box_pop: open a chatroom by selecting
       message2_box_pop_admin: the club, the round and the box.
       message2_box_pop_referee: the round and the box.
+      message2_box_pop_player_referee: the round and the box.
       message2_box_pop_player: the round.

--- a/config/locales/views/chatrooms/fr.yml
+++ b/config/locales/views/chatrooms/fr.yml
@@ -14,7 +14,7 @@ fr:
       message_invite: "> Message vers"
       send_btn: ⎷ Envoi
       back_btn: ←
-      chatroom_choice: Accéder à une chatroom
+      chatroom_choice: Accéder à une chatroom ouverte, ou
       chose_chatroom: "Choisir une chatroom ouverte: "
       chatroom_name: Nom de la chatroom
       confirm_btn: ⎷ Confirmer
@@ -28,10 +28,13 @@ fr:
       box: Numéro de box
       chatroom_created_flash: Création d'une nouvelle chatroom
       message1_box_pop: >
-        Nom des chatrooms :<br />
-        #[Nom du Club] - R[AA_NN]:B[Nº Box]<br />
-        AA_NN, est le numéro du round (AA est l'année du round, NN son rang dans l'année)
-      message2_box_pop: Ouvrir une chatroom en choisissant
+        Nom d'une chatroom:<br />
+        #[NomClub] - aaaa/mm_Rnn:Bbb<br /><br />
+        aaaa/mm : année et mois du tournoi,<br />
+        nn : index du round,<br />
+        bb : numéro de la box.
+      message2_box_pop: ouvrir une chatroom en choisissant
       message2_box_pop_admin: le club, le round et la box.
       message2_box_pop_referee: le round et la box.
+      message2_box_pop_player_referee: le round et la box.
       message2_box_pop_player: le round.

--- a/config/locales/views/chatrooms/nl.yml
+++ b/config/locales/views/chatrooms/nl.yml
@@ -14,7 +14,7 @@ nl:
       message_invite: "> Bericht naar"
       send_btn: ⎷ Versturen
       back_btn: ←
-      chatroom_choice: Toegang tot een chatroom
+      chatroom_choice: Toegang tot een open chatroom of
       chose_chatroom: "Kies een open chatroom: "
       chatroom_name: Chatroom naam
       confirm_btn: ⎷ Bevestigen
@@ -28,10 +28,13 @@ nl:
       box: Box nummer
       chatroom_created_flash: Newe chatroom gemaakt
       message1_box_pop: >
-        De namen van de chatrooms zijn als volgt opgebouwd:<br />
-        #[Club] - R[JJ_NN]:B[Boxnummer]<br />
-        JJ_NN is het ronde getal (JJ is het jaar van de ronde, RR de ronderang in het jaar)
-      message2_box_pop: Open een chatroom door
+        Namen van de chatrooms:<br />
+        #[ClubNaam] - jjjj/mm_Rnn:Bbb<br /><br />
+        jjjj/mm : tornoei jaar en mand,<br />
+        nn : ronderang,<br />
+        bb : box getal.
+      message2_box_pop: open een chatroom door
       message2_box_pop_admin: de club, ronde en box te selecteren.
       message2_box_pop_referee: de ronde en box te selecteren.
+      message2_box_pop_player_referee: de ronde en box te selecteren.
       message2_box_pop_player: de round te selecteren.

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -4,31 +4,30 @@ en:
       main_title: Social tennis in your club
       welcome_title: Welcome to your club's Social Tournament website
       p01: >
-        The mixed Singles Social Tournament is organized as a Box League with one round every month (or three months in some
+        The mixed Singles Social Tournament is organized as a Box League with one round every month (or more in some
         clubs). Points earned in each round of the Box League will accumulate to give an overall Tournament winner.
       p02: >
-        The winner will receive the Singles Box League Tournament trophy, listing on the club honors board and possibly some
+        The winner will receive the Singles Box League Tournament trophy 🏆, listing on the club honors board and possibly some
         champagne to celebrate at the end of the run.
-      p03: The league table will be updated and displayed on the league board at the end of each round.
+      p03_html: 🥇🥈🥉 The <b>league table</b> will be updated after each score entry and displayed on the league board at the end of each round.
       use_title: Your LeagueBox in a few clicks
-      p06: Easily follow the league table and see how you rank against other players in the box league.
       li01: My scores
       li02: All boxes
-      li03a: List view
-      li03b: Table view
-      li04: League Table
-      li05_html: Post your latest match score in %{inset}.<br>Your ranking is automatically updated.
       li06_html: >
         In %{inset} see at a glance every box in your league, and click on any box for
         more details.<br/>You can even go back to the previous rounds.
-      li07_html: Within any box, the %{inset_a} or the %{inset_b} show you the games and scores, and players' rankings.
-      li08_html: The %{inset} is always up to date, you can keep track of where every other players rank in the tournament.
+      li03a: List view
+      li03b: Table view
+      li07_html: Post your latest match score in the %{inset_a} or the %{inset_b} pages, or in %{inset_c}.<br>Your ranking is automatically updated.
+      li04a: round ranking
+      li04b: league table
+      li08_html: The %{inset_a} and the %{inset_b} are always up to date, showing how you rank against other players in the tournament.
       how_title: "The rounds: 4 simple steps"
       p04: "Each round lasts a month (or more in some clubs), and players compete within their allocated box."
-      li09_html: During the round period, play <b>every match in your box</b>.
+      li09_html: During the round period, <b>play every match</b> in your box.
       li10_html: After each match, either player enters the <b>match score</b>.
-      li11_html: <b>The league table</b> is updated automatically. You can also review the <b>boxes and match scores</b>.
-      li12_html: "<b>Promotion / relegation</b>: At the end of the round, the top two players will be promoted 1 box. The last two players will be relegated 1 box."
+      li11_html: The <b>round ranking</b> and <b>league table</b> are updated automatically.
+      li12_html: At the end of the round, the top two players will be <b>promoted</b> 1 box. The last two players will be <b>relegated</b> 1 box.
       li13: Overview & rules
       p05_html: Visit our %{inset} page for more details
       happy_tournament: Happy tournament!

--- a/config/locales/views/pages/fr.yml
+++ b/config/locales/views/pages/fr.yml
@@ -4,32 +4,31 @@ fr:
       main_title: Le tennis associatif de votre club
       welcome_title: Votre tournoi sur LeagueBox
       p01: >
-        Le Tournoi en Simples de votre club est organisé comme une Box League proposant un round chaque mois (ou chaque trimestre dans certains clubs).
+        Le Tournoi en Simples de votre club est organisé comme une Box League proposant un round chaque mois (ou plus dans certains clubs).
         Les points gagnés au cours de chaque round s'additionnent en un total cumulé qui déterminera le vainqueur du Tournoi.
       p02: >
-        Le vainqueur recevra le trophée du Tournoi Box League, son nom sur le tableau d'honneur et pourquoi pas
+        Le vainqueur recevra le trophée du Tournoi Box League 🏆, son nom sur le tableau d'honneur et pourquoi pas
         du champagne pour célébrer sa victoire à la fin du tournoi.
-      p03: La league table sera mise à jour automatiquement.
+      p03_html: 🥇🥈🥉 La <b>league table</b> sera mise à jour automatiquement.
       use_title: Votre LeagueBox en quelques clicks
-      p06: Suivez la league table pour vous comparer aux autres joueurs de votre box league.
       li01: Mes scores
       li02: Les box
-      li03a: Résultats en liste
-      li03b: Résultats en grille
-      li04: League Table
-      li05_html: Après chaque match, entrez votre score dans %{inset}.<br>Votre classement est mis à jour automatiquement.
       li06_html: >
         La page %{inset} montre toutes les box de la league:
-        accédez à la box de votre choix en cliquant dessus pour la consulter plus en détail.<br/>
+        accédez aux détails d'une box en cliquant dessus.<br/>
         Vous avez également accès aux rounds précédents.
-      li07_html: Pour chaque box, la page des %{inset_a} et celle des %{inset_b} vous détaillent les matchs et les scores.
-      li08_html: La %{inset} du round est toujours à jour, et vous pouvez vous comparer aux autres joueurs dans le tournoi.
+      li03a: Résultats en liste
+      li03b: Résultats en grille
+      li07_html: Après chaque match, entrez votre score dans les %{inset_a}, les %{inset_b}, ou dans %{inset_c}.<br>Votre classement est mis à jour automatiquement.
+      li04a: classement du round
+      li04b: league table
+      li08_html: Le %{inset_a} et la %{inset_b} du round sont toujours à jour, vous pouvez vous comparer aux autres joueurs du tournoi.
       how_title: "Les rounds: quatre étapes simples"
       p04: Chaque round dure un mois (ou plus selon les clubs), et les joueurs s'affrontent au sein de leur box.
-      li09_html: Pendant la durée du round, jouez <b>tous les matchs de votre box</b>.
-      li10_html: Après chaque match, vous ou votre adversaire entrez <b>le score du match</b>.
-      li11_html: <b>La league table</b> est mise à jour automatiquement. Vous pouvez également consulter <b>les box et les scores</b>.
-      li12_html: "<b>Promotion / relégation</b> : À la fin du round, les deux meilleurs joueurs sont promus d'une box. Les deux derniers sont relégués d'une box."
+      li09_html: Pendant la durée du round, <b>jouez tous les matchs</b> de votre box.
+      li10_html: Après chaque match, vous ou votre adversaire <b>entrez le score</b> du match.
+      li11_html: Le <b>classement du round</b> et la <b>league table</b> sont mis à jour automatiquement.
+      li12_html: À la fin du round, les deux meilleurs joueurs sont <b>promus</b> d'une box. Les deux derniers sont <b>relégués</b> d'une box.
       li13: Tournoi & règles
       p05_html: Consultez notre page %{inset} pour en savoir plus
       happy_tournament: Que les meilleurs gagnent!

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -4,30 +4,30 @@ nl:
       main_title: Verenigingstennis in jouw club
       welcome_title: Welkom op de LeagueBox-website
       p01: >
-        Het Singles Tournament wordt georganiseerd als een Box League en biedt elke maand een ronde (of elke drie maanden, in sommige club).
+        Het Singles Tournament wordt georganiseerd als een Box League en biedt elke maand een ronde (of meer, in sommige club).
         De tijdens elke ronde verdiende punten vormen een cumulatief totaal dat de winnaar van het toernooi bepaalt.
       p02: >
-        De winnaar ontvangt de Singles Box League Tournament-trofee, zijn of haar naam op de erelijst en waarom niet
+        De winnaar ontvangt de Singles Box League Tournament-trofee 🏆, zijn of haar naam op de erelijst en waarom niet
         champagne om zijn overwinning aan het einde van de ronde te vieren.
-      p03: De ranglijst wordt aan het einde van de rondes bijgewerkt en op het bord weergegeven.
+      p03_html: 🥇🥈🥉 De <b>league table</b> wordt aan het einde van de rondes bijgewerkt en op het bord weergegeven.
       use_title: Jouw LeagueBox in een paar klikken
-      p06: Volg de ranglijst om jezelf te vergelijken met andere spelers in je competitievak
       li01: Mijn scores
+      li05_html:
       li02: De boxen
-      li03a: Resultaten lijst
-      li03b: Resultatenraster
-      li04: League Table
-      li05_html: Voer je laatste score in %{inset}.<br>Je ranking wordt automatisch bijgewerkt.
       li06_html: >
         Op %{inset} zie je elke box in de competitie in één oogopslag en krijg je toegang tot de boxen in
         klik erop om het in detail te volgen.<br/>Je hebt ook toegang tot eerdere rondes.
-      li07_html: Binnen een box raadpleeg je de wedstrijd en scores, en de rangschikking van een speler in %{inset_a} of in %{inset_b}.
-      li08_html: De %{inset} wordt altijd bijgewerkt en je kunt de ranglijst van alle andere spelers in het toernooi volgen.
+      li03a: Resultaten lijst
+      li03b: Resultatenraster
+      li07_html: Voer je laatste score in %{inset_a}, in %{inset_b} of in %{inset_c}.<br>Je ranking wordt automatisch bijgewerkt.
+      li04a: ronde rangschikking
+      li04b: league table
+      li08_html: De %{inset_a} en de %{inset_b} worden altijd bijgewerkt en je kunt de ranglijst van alle andere spelers in het toernooi volgen.
       how_title: "De rondes: 4 eenvoudige stappen"
       p04: Elke ronde duurt een maand (of meer in sommige clubs) en spelers strijden in hun box.
-      li09_html: Gedurende de ronde speel <b>elke wedstrijd in je box</b>.
+      li09_html: Gedurende de ronde speel <b>elke wedstrijd</b> in je box.
       li10_html: Na elke wedstrijd voert een van de twee spelers <b>de wedstrijdscore</b> in.
-      li11_html: <b>De league table</b> wordt automatisch bijgewerkt. U kunt ook <b>de boxen en wedstrijdscoren</b> bekijken.
+      li11_html: De <b>ronde rangschikking</b> en de <b>league table</b> worden automatisch bijgewerkt.
       li12_html: "<b>Promotie / degradatie</b>: Aan het einde van de ronde gaan de twee beste spelers één vak omhoog. De laatste twee degraderen één vakje."
       li13: Toernooiregels
       p05_html: Bezoek onze pagina %{inset} voor meer informatie

--- a/config/locales/views/rounds/en.yml
+++ b/config/locales/views/rounds/en.yml
@@ -10,7 +10,7 @@ en:
           -1 = one box down,<br />
           -2 = two boxes down.<br /><br />
           Select 99 to remove player from next league round (e.g. if less than 2 games played).
-      message_boxes: player name, rank,<br />nb matches played, proposed box move
+      message_boxes: player name, player rank,<br />nb matches played, proposed box move
       league_start: "League start date :"
       start_date: "Start date :"
       end_date: "End date :"
@@ -24,7 +24,8 @@ en:
         one: Round created with %{players} players per box. Last player could not be accomodated.
         other: Round created with %{players} players per box. Last %{count} players could not be accommodated.
     edit:
-      round_end_title: Change the current round end date
+      round_end_title: Round end date
+      change_end_date: Change the current round end date
       not_authorised: This page is not authorised.
       select_club: Select a club
       club: Club

--- a/config/locales/views/rounds/fr.yml
+++ b/config/locales/views/rounds/fr.yml
@@ -24,7 +24,8 @@ fr:
         one: Round créé avec %{players} joueurs par box. Le dernier joueur n'a pu être inclus.
         other: Round créé avec %{players} joueurs par box. Les %{count} derniers joueurs n'ont pu être inclus.
     edit:
-      round_end_title: Changer la date de fin du round en cours
+      round_end_title: Fin du round en cours
+      change_end_date: Changer la date de fin du round en cours
       not_authorised: Cette page n'est pas autorisée.
       select_club: Choisir un club
       club: Club

--- a/config/locales/views/rounds/nl.yml
+++ b/config/locales/views/rounds/nl.yml
@@ -24,7 +24,8 @@ nl:
         one: Round gemaakt met %{players} spelers per box. De laatste speler konde niet worden ondergebracht.
         other: Round gemaakt met %{players} spelers per box. De laatste %{count} spelers konden niet worden ondergebracht.
     edit:
-      round_end_title: Wijzig de huidige einddatum van de ronde
+      round_end_title: Einddatum van de ronde
+      change_end_date: Wijzig de huidige einddatum van de ronde
       not_authorised: Deze pagina is niet geautoriseerd.
       select_club: Kies een club
       last_match_date: De laatste wedstrijd van de ronde werd gespeeld op %{date}

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -25,7 +25,7 @@ en:
       expired: round expired
       players: ", %{nb_players} players"
     select_round:
-      select_round_start: "Choose a round start date: "
+      select_round_start: "Choose another round start date: "
       confirm_btn: ⎷ Confirm
     select_club_round:
       select_club: "Select a club: "
@@ -50,7 +50,7 @@ en:
       website_admin: Website admin
       club_referee_html: "%{club_name} Referee"
     stats:
-      stats: Round stats
+      stats: 📈 round stats
       round: Round
       line1: <b>The round</b><br><i>%{start} to %{end}</i><br>
       line2: "%{players} players, %{boxes} boxes<br>"
@@ -59,7 +59,10 @@ en:
         one: 1 match
         other: "%{count} matches"
       nb_matches_played: ", %{count} played (%{ratio}%)<br>"
-      line3: "total days %{total_days}, %{days_left} days left (%{ratio}%)<br>"
+      line3:
+        zero: total days %{total_days}, 0 days left (%{ratio}%)<br>
+        one: total days %{total_days}, 1 day left (%{ratio}%)<br>
+        other: total days %{total_days}, %{count} days left (%{ratio}%)<br>
       line4: <b>My box</b><br>
       round_expired: round expired<br>
       line5: <b>My matches</b><br>

--- a/config/locales/views/shared/fr.yml
+++ b/config/locales/views/shared/fr.yml
@@ -25,7 +25,7 @@ fr:
       expired: round terminé
       players: "%{nb_players} joueurs"
     select_round:
-      select_round_start: "Départ du round: "
+      select_round_start: "Changer de round: "
       confirm_btn: ⎷ Confirmer
     select_club_round:
       select_club: "Choisir un club: "
@@ -51,7 +51,7 @@ fr:
       website_admin: Administrateur du site
       club_referee_html: "Referee du %{club_name}"
     stats:
-      stats: Stats du round
+      stats: 📈 stats du round
       round: Round
       line1: <b>Le round</b><br><i>%{start} au %{end}</i><br>
       line2: "%{players} joueurs, %{boxes} box<br>"
@@ -63,7 +63,10 @@ fr:
         zero: ", %{count} joué (%{ratio}%)<br>"
         one: ", %{count} joué (%{ratio}%)<br>"
         other: ", %{count} joués (%{ratio}%)<br>"
-      line3: "total %{total_days} jours, %{days_left} jours restants (%{ratio}%)<br>"
+      line3:
+        zero: total %{total_days} jours, 0 jour restant (%{ratio}%)<br>
+        one: total %{total_days} jours, 1 jour restant (%{ratio}%)<br>
+        other: total %{total_days} jours, %{count} jours restants (%{ratio}%)<br>
       line4: <b>Ma box</b><br>
       round_expired: round expiré<br>
       line5: <b>Mes matchs</b><br>

--- a/config/locales/views/shared/nl.yml
+++ b/config/locales/views/shared/nl.yml
@@ -25,7 +25,7 @@ nl:
       expired: ronde verlopen
       players: "%{nb_players} spellers"
     select_round:
-      select_round_start: "Ronde startdatum: "
+      select_round_start: "Andere ronde startdatum: "
       confirm_btn: ⎷ Bevestigen
     select_club_round:
       select_club: "Kies een club: "
@@ -51,7 +51,7 @@ nl:
       website_admin: Sitebeheerder (admin)
       club_referee_html: "Referee van %{club_name}"
     stats:
-      stats: Ronde stat
+      stats: 📈 ronde stat
       round: Ronde
       line1: "<b>Het ronde</b><br><i>%{start} tot %{end}</i><br>"
       line2: "%{players} spelers, %{boxes} boxen<br>"
@@ -60,7 +60,10 @@ nl:
         one: 1 wedstrijd
         other: "%{count} wedstrijden"
       nb_matches_played: ", %{count} gespeeld (%{ratio}%)<br>"
-      line3: "totaal %{total_days} dagen, %{days_left} dagen resterend (%{ratio}%)<br>"
+      line3:
+        zero: totaal %{total_days} dagen, 0 dag resterend (%{ratio}%)<br>
+        one: totaal %{total_days} dagen, 1 dag resterend (%{ratio}%)<br>
+        other: totaal %{total_days} dagen, %{count} dagen resterend (%{ratio}%)<br>
       line4: <b>Mijn box</b><br>
       round_expired: ronde verlopen<br>
       line5: <b>Mijn wedstrijden</b><br>

--- a/config/locales/views/user_box_scores/en.yml
+++ b/config/locales/views/user_box_scores/en.yml
@@ -29,8 +29,8 @@ en:
           <li>Ratio of games won to games played</li>
         </ol>
     action_buttons:
-      to_text_btn: Export to text file
-      to_csv_btn: Export to CSV file
+      to_text_btn: 📄 text file
+      to_csv_btn: 📄 CSV file
     table_data:
       matches:
         zero: 0 matches

--- a/config/locales/views/user_box_scores/fr.yml
+++ b/config/locales/views/user_box_scores/fr.yml
@@ -28,8 +28,8 @@ fr:
           <li>Ratio jeux gagnés sur jeux joués</li>
         </ol>
     action_buttons:
-      to_text_btn: Exporter en fichier texte
-      to_csv_btn: Exporter en CSV
+      to_text_btn: 📄 fichier texte
+      to_csv_btn: 📄 fichier CSV
     table_data:
       matches:
         zero: 0 match

--- a/config/locales/views/user_box_scores/nl.yml
+++ b/config/locales/views/user_box_scores/nl.yml
@@ -26,8 +26,8 @@ nl:
           <li>Verhouding tussen gewonnen games en gespeelde games</li>
         </ol>
     action_buttons:
-      to_text_btn: Exporteren naar tekstbestand
-      to_csv_btn: Exporteren naar CSV-bestand
+      to_text_btn: 📄 tekstbestand
+      to_csv_btn: 📄 CSV-bestand
     table_data:
       matches:
         zero: 0 wed.


### PR DESCRIPTION
The referee and player referee did not have access to the chatroom and change round end date pages.

Changed the chatroom name structure to
#[ClubName] - yyyy/mm_Rnn:Bbb<br /><br />
        yyyy/mm : tournament year/month,<br />
        nn : round number,<br />
        bb : box number.

Dryed the code

In the home page, simplified the text.