### PR TITLE
title and popover in index league

### DIFF
--- a/app/controllers/user_box_scores_controller.rb
+++ b/app/controllers/user_box_scores_controller.rb
@@ -92,6 +92,9 @@ class UserBoxScoresController < ApplicationController
       if @round.doubles_format? && doubles_context
         @doubles_mode = true
         @league_start = @round.league_start
+        # Same scope as singles path so index_league can render title + rounds popover (not only the duplicate top title).
+        rounds_scope = Round.where(league_start: @league_start, club_id: @club.id)
+        @rounds = tf.present? ? rounds_scope.where(tournament_format: tf) : rounds_scope
         if params[:order] && (params[:exsort] == params[:sort])
           @order = params[:order].to_i
         else

--- a/app/views/user_box_scores/index_league.html.erb
+++ b/app/views/user_box_scores/index_league.html.erb
@@ -7,18 +7,14 @@
 <div class="<%= class_names("container": !@is_mobile, "px-2 px-md-3": @is_mobile) %>" data-controller="toggle"
      data-toggle-screen-type-value="<%= @is_mobile ? "mobile" : "widescreen" %>">
   <% if !@is_mobile %><br><% end %>
-
-  <%# Page Title Section: Tournament league table with rounds popover %>
-  <div class="<%= class_names("one-liner": !@is_mobile, "d-flex flex-column": @is_mobile) %> text-size">
-  <h3 class="<%= class_names("mb-0": !@is_mobile, "mb-2 text-center": @is_mobile) %>">
-    <%= t('.league_table_title', league_start: l(@league_start, format: :yyymm_date)) %>
-  </h3>
-</div>
+  <%# Title + rounds popover: singles (below) and doubles (controller sets @rounds before early return) %>
   <% if @rounds %>
     <div class="<%= class_names("one-liner": !@is_mobile, "d-flex flex-column text-center": @is_mobile) %> text-size">
       <%# Build popover message with all rounds in the tournament %>
       <% boxes = @rounds.map{ |round| "#{round.round_label_round_part}: #{round.start_date.strftime('%d/%m/%Y')} - #{round.end_date.strftime('%d/%m/%Y')},<br />" }.sort.join[0...-7]
-      message = "<br /><u>#{t(".rounds")} #{l(@league_start, format: :yyymm_date)}:</u><br />#{boxes}" %>
+      format_name = tournament_format_default_section_title(@round&.tournament_format)
+      header = "<b>#{h(@club&.name)} - #{h(format_name)}</b><br />"
+      message = "#{header}<u>#{t(".rounds")} #{l(@league_start, format: :yyymm_date)}:</u><br />#{boxes}" %>
       <%# Title popover: tag helper entity-escapes content (avoid raw data-bs-content interpolation; it breaks on quotes and &) %>
       <%= tag.div data: {
         controller: "popover",

--- a/config/locales/views/user_box_scores/fr.yml
+++ b/config/locales/views/user_box_scores/fr.yml
@@ -36,7 +36,7 @@ fr:
         </ol>
         <br /><br />
     action_buttons:
-      all_boxes_link: 📦 les box
+      all_boxes_link: 📦 les box du round
       round_ranking_btn: 🏆 classement du round
       to_text_btn: 📄 texte
       to_csv_btn: 📄 CSV


### PR DESCRIPTION
**Make the popover appear for doubles and padel in index_league**
1. `app/views/user_box_scores/index_league.html.erb`

Removed the first title block (the whole first container that only held that `<h3>`).
Kept one `@rounds` popover block (title + rounds popover + print header).

2. `app/controllers/user_box_scores_controller.rb`

In the doubles branch, before return, set @rounds the same way as singles (same league_start, club_id, and optional tournament_format filter):

- `rounds_scope = Round.where(league_start: @league_start, club_id: @club.id)`

- `@rounds = tf.present? ? rounds_scope.where(tournament_format: tf) : rounds_scope`

So for doubles tennis and padel, the page now uses the same title + hover popover as singles, with one visible title.

**Added first line in the popover**
The popover in `app/views/user_box_scores/index_league.html.erb` now starts with a bold first line:

- Club name - tournament format

I also made it safe/robust by escaping both values:

- club: `@club&.name`
- format label: `tournament_format_default_section_title(@round&.tournament_format)`

So the popover structure is now:

1. `<b>Club - Format</b>`
2. underlined rounds section header
3. round date lines as before.